### PR TITLE
Updated serialization of output to ensure that the casing is correct for pre-determined JToken keys

### DIFF
--- a/src/SwaggerMerge/Merge/Configuration/Input/SwaggerInputPathOperationExclusionConfiguration.cs
+++ b/src/SwaggerMerge/Merge/Configuration/Input/SwaggerInputPathOperationExclusionConfiguration.cs
@@ -1,8 +1,10 @@
 namespace SwaggerMerge.Merge.Configuration.Input;
 
+using Newtonsoft.Json.Linq;
+
 /// <summary>
 /// Defines the configuration for defining path operation exclusions based on a defined property match.
 /// </summary>
-public class SwaggerInputPathOperationExclusionConfiguration : Dictionary<string, object>
+public class SwaggerInputPathOperationExclusionConfiguration : Dictionary<string, JToken>
 {
 }

--- a/src/SwaggerMerge/Merge/SwaggerMerger.Definitions.cs
+++ b/src/SwaggerMerge/Merge/SwaggerMerger.Definitions.cs
@@ -7,185 +7,158 @@ internal static partial class SwaggerMerger
 {
     private static SwaggerDocumentDefinitions GetUsedDefinitions(SwaggerDocument document)
     {
-        void ProcessPropertyItemReference(
-            KeyValuePair<string, SwaggerDocumentSchema> property,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (property.Value.Items?.Reference == null)
-            {
-                return;
-            }
-
-            var expectedDefinition = GetDefinitionByReference(property.Value.Items.Reference, document.Definitions);
-
-            if (string.IsNullOrWhiteSpace(expectedDefinition.Key) || usedDefinitions.ContainsKey(expectedDefinition.Key))
-            {
-                return;
-            }
-
-            usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-            ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-        }
-
-        void ProcessPropertyReference(
-            KeyValuePair<string, SwaggerDocumentSchema> property,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (property.Value.Reference == null)
-            {
-                return;
-            }
-
-            var expectedDefinition = GetDefinitionByReference(property.Value.Reference, document.Definitions);
-
-            if (string.IsNullOrWhiteSpace(expectedDefinition.Key) || usedDefinitions.ContainsKey(expectedDefinition.Key))
-            {
-                return;
-            }
-
-            usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-            ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-        }
-
-        void ProcessDefinitionProperties(
-            KeyValuePair<string, SwaggerDocumentSchema> definition,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (definition.Value.Properties == null)
-            {
-                return;
-            }
-
-            foreach (var property in definition.Value.Properties)
-            {
-                ProcessPropertyReference(property, usedDefinitions);
-                ProcessPropertyItemReference(property, usedDefinitions);
-            }
-        }
-
-        void ProcessResponseSchemaItemReference(
-            SwaggerDocumentResponse response,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (response.Schema is not { Items.Reference: { } })
-            {
-                return;
-            }
-
-            var expectedDefinition =
-                GetDefinitionByReference(response.Schema?.Reference, document.Definitions);
-
-            if (string.IsNullOrWhiteSpace(expectedDefinition.Key) || usedDefinitions.ContainsKey(expectedDefinition.Key))
-            {
-                return;
-            }
-
-            usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-            ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-        }
-
-        void ProcessResponseSchemaReference(
-            SwaggerDocumentResponse response,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (response.Schema is not { Reference: { } })
-            {
-                return;
-            }
-
-            var expectedDefinition =
-                GetDefinitionByReference(response.Schema?.Reference, document.Definitions);
-
-            if (string.IsNullOrWhiteSpace(expectedDefinition.Key) || usedDefinitions.ContainsKey(expectedDefinition.Key))
-            {
-                return;
-            }
-
-            usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-            ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-        }
-
-        void ProcessParameterSchemaItemReference(
-            SwaggerDocumentOperation operation,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (operation.Parameters == null)
-            {
-                return;
-            }
-
-            foreach (var referenceParameter in operation.Parameters.Where(x =>
-                         x.Schema is { Items.Reference: { } }))
-            {
-                var expectedDefinition =
-                    GetDefinitionByReference(referenceParameter.Schema?.Items?.Reference, document.Definitions);
-
-                if (string.IsNullOrWhiteSpace(expectedDefinition.Key) ||
-                    usedDefinitions.ContainsKey(expectedDefinition.Key))
-                {
-                    continue;
-                }
-
-                usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-                ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-            }
-        }
-
-        void ProcessParameterSchemaReference(
-            SwaggerDocumentOperation operation,
-            SwaggerDocumentDefinitions usedDefinitions)
-        {
-            if (operation.Parameters == null)
-            {
-                return;
-            }
-
-            foreach (SwaggerDocumentParameter referenceParameter in operation.Parameters.Where(x =>
-                         x.Schema is { Reference: { } }))
-            {
-                var expectedDefinition =
-                    GetDefinitionByReference(referenceParameter.Schema?.Reference, document.Definitions);
-
-                if (string.IsNullOrWhiteSpace(expectedDefinition.Key) ||
-                    usedDefinitions.ContainsKey(expectedDefinition.Key))
-                {
-                    continue;
-                }
-
-                usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
-                ProcessDefinitionProperties(expectedDefinition, usedDefinitions);
-            }
-        }
-
-        SwaggerDocumentDefinitions usedDefinitions = new SwaggerDocumentDefinitions();
-
         if (document.Definitions == null || document.Paths == null)
         {
-            return usedDefinitions;
+            return new SwaggerDocumentDefinitions();
+        }
+
+        var pathDefinitions = GetDocumentPathDefinitions(document);
+        PopulateDefinitionDefinitions(pathDefinitions, new SwaggerDocumentDefinitions(pathDefinitions), document);
+
+        return pathDefinitions;
+    }
+
+    private static void PopulateDefinitionDefinitions(
+        SwaggerDocumentDefinitions pathDefinitions,
+        SwaggerDocumentDefinitions definitions,
+        SwaggerDocument document)
+    {
+        var definitionDefinitions = new SwaggerDocumentDefinitions();
+
+        if (document.Definitions == null)
+        {
+            return;
+        }
+
+        foreach (var definition in definitions)
+        {
+            var definitionReferences = new List<string>();
+
+            PopulateReferences(definitionReferences, definition.Value);
+
+            var keyedReferences = definitionReferences.Select(r => r.Replace("#/definitions/", string.Empty));
+
+            if (keyedReferences.All(pathDefinitions.ContainsKey))
+            {
+                continue;
+            }
+
+            PopulateReferenceDefinitions(definitionReferences, document.Definitions, definitionDefinitions);
+
+            // Adds any new definitions to the path definitions.
+            foreach (var d in definitionDefinitions.Where(d => !pathDefinitions.ContainsKey(d.Key)))
+            {
+                pathDefinitions.Add(d.Key, d.Value);
+            }
+
+            // If we do have them, lets have a look for that definitions definitions
+            if (definitionDefinitions.Any())
+            {
+                PopulateDefinitionDefinitions(pathDefinitions, definitionDefinitions, document);
+            }
+        }
+
+    }
+
+    private static SwaggerDocumentDefinitions GetDocumentPathDefinitions(SwaggerDocument document)
+    {
+        SwaggerDocumentDefinitions definitions = new SwaggerDocumentDefinitions();
+
+        var definedPathReferences = new List<string>();
+
+        if (document.Paths == null || document.Definitions == null)
+        {
+            return definitions;
         }
 
         foreach (var operation in document.Paths.SelectMany(path => path.Value.Select(method => method.Value)))
         {
             if (operation.Parameters != null)
             {
-                ProcessParameterSchemaReference(operation, usedDefinitions);
-                ProcessParameterSchemaItemReference(operation, usedDefinitions);
+                foreach (var parameter in operation.Parameters)
+                {
+                    PopulateReferences(definedPathReferences, parameter);
+                }
             }
 
-            if (operation.Responses != null)
+            if (operation.Responses != null && operation.Responses.Any())
             {
-                foreach (var response in operation.Responses.Select(operationResponse => operationResponse.Value))
+                foreach (var response in operation.Responses)
                 {
-                    ProcessResponseSchemaReference(response, usedDefinitions);
-                    ProcessResponseSchemaItemReference(response, usedDefinitions);
+                    PopulateReferences(definedPathReferences, response.Value);
                 }
+            }
+
+            if (operation.AdditionalProperties == null || !operation.AdditionalProperties.Any())
+            {
+                continue;
+            }
+
+            foreach (var additionalProperty in operation.AdditionalProperties)
+            {
+                PopulateReferences(definedPathReferences, additionalProperty.Value);
             }
         }
 
-        return usedDefinitions;
+        PopulateReferenceDefinitions(definedPathReferences, document.Definitions, definitions);
+
+        return definitions;
     }
 
-    private static KeyValuePair<string, SwaggerDocumentSchema> GetDefinitionByReference(
+    private static void PopulateReferenceDefinitions(
+        IEnumerable<string> references,
+        SwaggerDocumentDefinitions allDefinitions,
+        SwaggerDocumentDefinitions usedDefinitions)
+    {
+        foreach (var expectedDefinition in references
+                     .Select(reference => GetDefinitionByReference(reference, allDefinitions))
+                     .Where(expectedDefinition => !string.IsNullOrWhiteSpace(expectedDefinition.Key) &&
+                                                  !usedDefinitions.ContainsKey(expectedDefinition.Key)))
+        {
+            usedDefinitions.AddOrUpdate(expectedDefinition.Key, expectedDefinition.Value);
+        }
+    }
+
+    private static void PopulateReferences(ICollection<string> references, SwaggerDocumentProperty data)
+    {
+        if (data.Reference != null)
+        {
+            if (!references.Contains(data.Reference))
+            {
+                references.Add(data.Reference);
+            }
+        }
+
+        if (data.Items != null)
+        {
+            PopulateReferences(references, data.Items);
+        }
+
+        if (data.Schema != null)
+        {
+            PopulateReferences(references, data.Schema);
+        }
+
+        if (data.Properties != null && data.Properties.Any())
+        {
+            foreach (var property in data.Properties)
+            {
+                PopulateReferences(references, property.Value);
+            }
+        }
+
+        if (data.AdditionalProperties == null || !data.AdditionalProperties.Any())
+        {
+            return;
+        }
+
+        foreach (var additionalProperty in data.AdditionalProperties)
+        {
+            PopulateReferences(references, additionalProperty.Value);
+        }
+    }
+
+    private static KeyValuePair<string, SwaggerDocumentProperty> GetDefinitionByReference(
         string? reference,
         SwaggerDocumentDefinitions allDefinitions)
     {

--- a/src/SwaggerMerge/Merge/SwaggerMerger.Inputs.cs
+++ b/src/SwaggerMerge/Merge/SwaggerMerger.Inputs.cs
@@ -7,7 +7,7 @@ using SwaggerMerge.Merge.Configuration.Input;
 internal static partial class SwaggerMerger
 {
     private static void UpdateOutputPathsFromInput(
-        SwaggerDocument output,
+        SwaggerDocument? output,
         SwaggerInputConfiguration inputConfig,
         SwaggerDocument input)
     {
@@ -28,7 +28,7 @@ internal static partial class SwaggerMerger
 
             outputPath = StripStartFromPath(outputPath, inputConfig);
             outputPath = PrependToPath(outputPath, inputConfig);
-            output.Paths.AddOrUpdate(outputPath, path.Value);
+            output?.Paths.AddOrUpdate(outputPath, path.Value);
         }
     }
 
@@ -56,10 +56,10 @@ internal static partial class SwaggerMerger
     }
 
     private static void UpdateOutputDefinitionsFromInput(
-        SwaggerDocument output,
+        SwaggerDocument? output,
         SwaggerDocument input)
     {
-        if (input.Definitions == null || output.Definitions == null)
+        if (input.Definitions == null || output?.Definitions == null)
         {
             return;
         }
@@ -91,12 +91,9 @@ internal static partial class SwaggerMerger
             {
                 // Remove any paths where the additional properties are included in the exclusions.
                 foreach (var (_, _) in inputConfig.Path.OperationExclusions.Where(
-                             pathOperationExclusion => operation.AdditionalProperties != null &&
-                                                       operation.AdditionalProperties.ContainsKey(
-                                                           pathOperationExclusion.Key) &&
-                                                       operation.AdditionalProperties[
-                                                               pathOperationExclusion.Key]
-                                                           .Equals(pathOperationExclusion.Value)))
+                             pathOperationExclusion => operation.JTokenProperties != null &&
+                                                       operation.JTokenProperties.ContainsKey(pathOperationExclusion.Key) &&
+                                                       operation.JTokenProperties[pathOperationExclusion.Key].Equals(pathOperationExclusion.Value)))
                 {
                     pathOperations.Remove(method);
                 }

--- a/src/SwaggerMerge/Merge/SwaggerMerger.cs
+++ b/src/SwaggerMerge/Merge/SwaggerMerger.cs
@@ -28,8 +28,13 @@ internal static partial class SwaggerMerger
         Console.WriteLine($"Merged {config.Inputs.Count()} files into '{config.Output.File}'");
     }
 
-    private static void FinalizeOutput(SwaggerDocument output, string outputTitle, SwaggerMergeConfiguration config)
+    private static void FinalizeOutput(SwaggerDocument? output, string outputTitle, SwaggerMergeConfiguration config)
     {
+        if (output == null)
+        {
+            return;
+        }
+
         // Where exclusions have been specified, remove any definitions from the output where they are no longer valid
         if (config.Inputs.Any(x => x.Path is { OperationExclusions: { } } && x.Path.OperationExclusions.Any()))
         {

--- a/src/SwaggerMerge/Program.cs
+++ b/src/SwaggerMerge/Program.cs
@@ -24,7 +24,7 @@ public class Program
         }
         catch (SwaggerMergeException sme)
         {
-            Console.WriteLine(sme);
+            Console.WriteLine(sme.Message);
         }
         catch (Exception e)
         {

--- a/src/SwaggerMerge/Program.cs
+++ b/src/SwaggerMerge/Program.cs
@@ -1,7 +1,7 @@
 namespace SwaggerMerge;
 
+using Merge.Configuration;
 using SwaggerMerge.Merge;
-using SwaggerMerge.Merge.Configuration;
 using SwaggerMerge.Merge.Exceptions;
 using SwaggerMerge.Serialization;
 
@@ -24,7 +24,7 @@ public class Program
         }
         catch (SwaggerMergeException sme)
         {
-            Console.WriteLine(sme.Message);
+            Console.WriteLine(sme);
         }
         catch (Exception e)
         {
@@ -41,9 +41,9 @@ public class Program
             config = await JsonFile.LoadFileAsync<SwaggerMergeConfiguration>(configFilePath);
             Directory.SetCurrentDirectory(Path.GetDirectoryName(configFilePath));
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            throw new SwaggerMergeException("The provided Swagger merge configuration file is not valid.");
+            throw new SwaggerMergeException("The provided Swagger merge configuration file is not valid.", ex);
         }
 
         return config;

--- a/src/SwaggerMerge/Serialization/JsonFile.cs
+++ b/src/SwaggerMerge/Serialization/JsonFile.cs
@@ -1,30 +1,21 @@
 namespace SwaggerMerge.Serialization;
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 internal static class JsonFile
 {
-    private static readonly JsonSerializerSettings InputSettings = new()
+    internal static readonly JsonSerializerSettings Settings = new()
     {
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-        Formatting = Formatting.Indented
-    };
-
-    private static readonly JsonSerializerSettings OutputSettings = new()
-    {
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
         MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
         Formatting = Formatting.Indented,
-        NullValueHandling = NullValueHandling.Ignore
+        NullValueHandling = NullValueHandling.Ignore,
     };
 
     public static async Task<T> LoadFileAsync<T>(string filePath)
         where T : class
     {
         var content = await File.ReadAllTextAsync(filePath);
-        var deserializedContent = JsonConvert.DeserializeObject<T>(content, InputSettings);
+        var deserializedContent = JsonConvert.DeserializeObject<T>(content, Settings);
         if (deserializedContent == null)
         {
             throw new InvalidOperationException(
@@ -37,7 +28,7 @@ internal static class JsonFile
     public static async Task SaveFileAsync<T>(string filePath, T data)
         where T : class
     {
-        var content = JsonConvert.SerializeObject(data, OutputSettings);
+        var content = JsonConvert.SerializeObject(data, Settings);
         await File.WriteAllTextAsync(filePath, content);
     }
 }

--- a/src/SwaggerMerge/Swagger/SwaggerDocument.cs
+++ b/src/SwaggerMerge/Swagger/SwaggerDocument.cs
@@ -1,6 +1,11 @@
 namespace SwaggerMerge.Swagger;
 
+using System.Globalization;
+using System.Runtime.Serialization;
+using MADE.Collections;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serialization;
 
 /// <summary>
 /// Defines the detail of a Swagger document.
@@ -10,69 +15,129 @@ public class SwaggerDocument
     /// <summary>
     /// Gets or sets the Swagger specification version.
     /// </summary>
-    [JsonProperty("swagger")]
+    [JsonProperty("swagger", NullValueHandling = NullValueHandling.Ignore)]
     public string SwaggerVersion { get; set; } = "2.0";
 
     /// <summary>
     /// Gets or sets the metadata about the API.
     /// </summary>
+    [JsonProperty("info", NullValueHandling = NullValueHandling.Ignore)]
     public SwaggerDocumentInfo Info { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the host (name or IP) serving the API.
     /// </summary>
+    [JsonProperty("host", NullValueHandling = NullValueHandling.Ignore)]
     public string? Host { get; set; }
 
     /// <summary>
     /// Gets or sets the base path on which the API is served, which is relative to the host.
     /// </summary>
+    [JsonProperty("basePath", NullValueHandling = NullValueHandling.Ignore)]
     public string? BasePath { get; set; }
 
     /// <summary>
     /// Gets or sets the transfer protocol of the API.
     /// </summary>
+    [JsonProperty("schemes", NullValueHandling = NullValueHandling.Ignore)]
     public List<string>? Schemes { get; set; }
 
     /// <summary>
     /// Gets or sets a list of MIME types the APIs can produce.
     /// </summary>
+    [JsonProperty("produces", NullValueHandling = NullValueHandling.Ignore)]
     public List<string>? Produces { get; set; }
 
     /// <summary>
     /// Gets or sets the available paths and operations for the API.
     /// </summary>
+    [JsonProperty("paths", NullValueHandling = NullValueHandling.Ignore)]
     public SwaggerDocumentPaths? Paths { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the data types produced and consumed by operations.
     /// </summary>
+    [JsonProperty("definitions", NullValueHandling = NullValueHandling.Ignore)]
     public SwaggerDocumentDefinitions? Definitions { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the parameters to be reused across operations.
     /// </summary>
-    public SwaggerDocumentParametersDefinitions? Parameters { get; set; } = new();
+    [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string, SwaggerDocumentProperty>? Parameters { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the responses to be reused across operations.
     /// </summary>
-    public SwaggerDocumentResponsesDefinitions? Responses { get; set; } = new();
+    [JsonProperty("responses", NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string, SwaggerDocumentProperty>? Responses { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the security scheme to be reused across the specification.
     /// </summary>
+    [JsonProperty("securityDefinitions", NullValueHandling = NullValueHandling.Ignore)]
     public SwaggerDocumentSecurityDefinitions? SecurityDefinitions { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the security options available in the Swagger document.
     /// </summary>
+    [JsonProperty("security", NullValueHandling = NullValueHandling.Ignore)]
     public List<SwaggerDocumentSecurityRequirement>? Security { get; set; } = new();
 
     /// <summary>
     /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
     /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
+    [JsonIgnore]
+    public Dictionary<string, SwaggerDocumentProperty>? AdditionalProperties { get; set; }
+
+    [JsonExtensionData] public Dictionary<string, JToken>? JTokenProperties { get; set; }
+
+    private static SwaggerDocumentProperty ToSwaggerDocumentProperty(JToken? jsonObject)
+    {
+        if (jsonObject == null)
+        {
+            return new SwaggerDocumentProperty();
+        }
+
+        using StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+        JsonTextWriter jw = new JsonTextWriter(sw);
+        jsonObject.WriteTo(jw);
+        var json = sw.ToString();
+        return JsonConvert.DeserializeObject<SwaggerDocumentProperty>(json, JsonFile.Settings) ?? new SwaggerDocumentProperty();
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        var objectTokens = JTokenProperties?.Where(x => x.Value is JObject).ToList();
+
+        if (objectTokens == null || !objectTokens.Any())
+        {
+            return;
+        }
+
+        this.AdditionalProperties = objectTokens.ToDictionary(
+            x => x.Key,
+            x => ToSwaggerDocumentProperty(x.Value as JObject));
+
+        this.JTokenProperties.RemoveRange(objectTokens);
+    }
+
+
+    [OnSerializing]
+    private void OnSerializing(StreamingContext context)
+    {
+        var additionalProperties = AdditionalProperties?.ToDictionary(
+            x => x.Key,
+            x => JToken.FromObject(x.Value));
+
+        if (additionalProperties == null)
+        {
+            return;
+        }
+
+        JTokenProperties.AddRange(additionalProperties);
+    }
 }
 
 /// <summary>
@@ -97,48 +162,105 @@ public class SwaggerDocumentSecurityScheme
     /// <summary>
     /// Gets or sets the type of security scheme.
     /// </summary>
+    [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
     public string? Type { get; set; }
 
     /// <summary>
     /// Gets or sets a short description of the security scheme.
     /// </summary>
+    [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
     public string? Description { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the header or query parameter to be used.
     /// </summary>
+    [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
     public string? Name { get; set; }
 
     /// <summary>
     /// Gets or sets the location of the API key.
     /// </summary>
+    [JsonProperty("in", NullValueHandling = NullValueHandling.Ignore)]
     public string? In { get; set; }
 
     /// <summary>
     /// Gets or sets the flow used by the OAuth2 security scheme.
     /// </summary>
+    [JsonProperty("flow", NullValueHandling = NullValueHandling.Ignore)]
     public string? Flow { get; set; }
 
     /// <summary>
     /// Gets or sets the authorization URL to be used for this flow.
     /// </summary>
+    [JsonProperty("authorizationUrl", NullValueHandling = NullValueHandling.Ignore)]
     public string? AuthorizationUrl { get; set; }
 
     /// <summary>
     /// Gets or sets the token URL to be used for this flow.
     /// </summary>
+    [JsonProperty("tokenUrl", NullValueHandling = NullValueHandling.Ignore)]
     public string? TokenUrl { get; set; }
 
     /// <summary>
     /// Gets or sets the available scopes for the OAuth2 security scheme.
     /// </summary>
+    [JsonProperty("scopes", NullValueHandling = NullValueHandling.Ignore)]
     public SwaggerDocumentScopes? Scopes { get; set; }
 
     /// <summary>
     /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
     /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
+    [JsonIgnore]
+    public Dictionary<string, SwaggerDocumentProperty>? AdditionalProperties { get; set; }
+
+    [JsonExtensionData] public Dictionary<string, JToken>? JTokenProperties { get; set; }
+
+    private static SwaggerDocumentProperty ToSwaggerDocumentProperty(JToken? jsonObject)
+    {
+        if (jsonObject == null)
+        {
+            return new SwaggerDocumentProperty();
+        }
+
+        using StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+        JsonTextWriter jw = new JsonTextWriter(sw);
+        jsonObject.WriteTo(jw);
+        var json = sw.ToString();
+        return JsonConvert.DeserializeObject<SwaggerDocumentProperty>(json, JsonFile.Settings) ?? new SwaggerDocumentProperty();
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        var objectTokens = JTokenProperties?.Where(x => x.Value is JObject).ToList();
+
+        if (objectTokens == null || !objectTokens.Any())
+        {
+            return;
+        }
+
+        this.AdditionalProperties = objectTokens.ToDictionary(
+            x => x.Key,
+            x => ToSwaggerDocumentProperty(x.Value as JObject));
+
+        this.JTokenProperties.RemoveRange(objectTokens);
+    }
+
+
+    [OnSerializing]
+    private void OnSerializing(StreamingContext context)
+    {
+        var additionalProperties = AdditionalProperties?.ToDictionary(
+            x => x.Key,
+            x => JToken.FromObject(x.Value));
+
+        if (additionalProperties == null)
+        {
+            return;
+        }
+
+        JTokenProperties.AddRange(additionalProperties);
+    }
 }
 
 /// <summary>
@@ -149,24 +271,18 @@ public class SwaggerDocumentScopes : Dictionary<string, object>
 }
 
 /// <summary>
-/// Defines the details of an object to hold responses to be reused across operations.
-/// </summary>
-public class SwaggerDocumentResponsesDefinitions : Dictionary<string, SwaggerDocumentResponse>
-{
-}
-
-/// <summary>
-/// Defines the details of an object to hold parameters to be reused across operations.
-/// </summary>
-public class SwaggerDocumentParametersDefinitions : Dictionary<string, SwaggerDocumentParameter>
-{
-}
-
-/// <summary>
 /// Defines the details of an object to hold data types that can be consumed and produced by operations.
 /// </summary>
-public class SwaggerDocumentDefinitions : Dictionary<string, SwaggerDocumentSchema>
+public class SwaggerDocumentDefinitions : Dictionary<string, SwaggerDocumentProperty>
 {
+    public SwaggerDocumentDefinitions()
+    {
+    }
+
+    public SwaggerDocumentDefinitions(IDictionary<string, SwaggerDocumentProperty> dictionary)
+        : base(dictionary)
+    {
+    }
 }
 
 /// <summary>
@@ -177,11 +293,13 @@ public class SwaggerDocumentInfo
     /// <summary>
     /// Gets or sets the title of the API.
     /// </summary>
+    [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
     public string Title { get; set; }
 
     /// <summary>
     /// Gets or sets the version of the API.
     /// </summary>
+    [JsonProperty("version", NullValueHandling = NullValueHandling.Ignore)]
     public string Version { get; set; }
 }
 
@@ -207,230 +325,193 @@ public class SwaggerDocumentOperation
     /// <summary>
     /// Gets or sets a list of tags for API documentation control.
     /// </summary>
+    [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
     public List<string> Tags { get; set; } = new();
 
     /// <summary>
     /// Gets or sets a short summary of what the operation does.
     /// </summary>
+    [JsonProperty("summary", NullValueHandling = NullValueHandling.Ignore)]
     public string? Summary { get; set; }
 
     /// <summary>
     /// Gets or sets a verbose explanation of the operation behavior.
     /// </summary>
+    [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
     public string? Description { get; set; }
 
     /// <summary>
     /// Gets or sets the unique string used to identify the operation.
     /// </summary>
+    [JsonProperty("operationId", NullValueHandling = NullValueHandling.Ignore)]
     public string? OperationId { get; set; }
 
     /// <summary>
     /// Gets or sets a list of MIME types the APIs can produce.
     /// </summary>
+    [JsonProperty("produces", NullValueHandling = NullValueHandling.Ignore)]
     public List<string>? Produces { get; set; }
 
     /// <summary>
     /// Gets or sets a list of parameters that are applicable for this operation.
     /// </summary>
-    public List<SwaggerDocumentParameter>? Parameters { get; set; }
+    [JsonProperty("parameters", NullValueHandling = NullValueHandling.Ignore)]
+    public List<SwaggerDocumentProperty>? Parameters { get; set; }
 
     /// <summary>
     /// Gets or sets the list of possible responses as they are returned from executing this operation.
     /// </summary>
-    public SwaggerDocumentResponses? Responses { get; set; }
+    [JsonProperty("responses", NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string, SwaggerDocumentProperty>? Responses { get; set; }
 
     /// <summary>
     /// Gets or sets the transfer protocol of the API.
     /// </summary>
+    [JsonProperty("schemes", NullValueHandling = NullValueHandling.Ignore)]
     public List<string>? Schemes { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this operation is deprecated.
     /// </summary>
-    public bool Deprecated { get; set; } = false;
+    [JsonProperty("deprecated", NullValueHandling = NullValueHandling.Ignore)]
+    public bool Deprecated { get; set; }
 
     /// <summary>
     /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
     /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
+    [JsonIgnore]
+    public Dictionary<string, SwaggerDocumentProperty>? AdditionalProperties { get; set; }
+
+    [JsonExtensionData] public Dictionary<string, JToken>? JTokenProperties { get; set; }
+
+    private static SwaggerDocumentProperty ToSwaggerDocumentProperty(JToken? jsonObject)
+    {
+        if (jsonObject == null)
+        {
+            return new SwaggerDocumentProperty();
+        }
+
+        using StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+        JsonTextWriter jw = new JsonTextWriter(sw);
+        jsonObject.WriteTo(jw);
+        var json = sw.ToString();
+        return JsonConvert.DeserializeObject<SwaggerDocumentProperty>(json, JsonFile.Settings) ?? new SwaggerDocumentProperty();
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        var objectTokens = JTokenProperties?.Where(x => x.Value is JObject).ToList();
+
+        if (objectTokens == null || !objectTokens.Any())
+        {
+            return;
+        }
+
+        this.AdditionalProperties = objectTokens.ToDictionary(
+            x => x.Key,
+            x => ToSwaggerDocumentProperty(x.Value as JObject));
+
+        this.JTokenProperties.RemoveRange(objectTokens);
+    }
+
+
+    [OnSerializing]
+    private void OnSerializing(StreamingContext context)
+    {
+        var additionalProperties = AdditionalProperties?.ToDictionary(
+            x => x.Key,
+            x => JToken.FromObject(x.Value));
+
+        if (additionalProperties == null)
+        {
+            return;
+        }
+
+        JTokenProperties.AddRange(additionalProperties);
+    }
 }
 
 /// <summary>
-/// Defines the details for the expected responses of an operation.
+/// Defines the detail of a generic Swagger document property.
 /// </summary>
-public class SwaggerDocumentResponses : Dictionary<string, SwaggerDocumentResponse>
-{
-}
-
-/// <summary>
-/// Defines the detail of a response of a single operation.
-/// </summary>
-public class SwaggerDocumentResponse
-{
-    /// <summary>
-    /// Gets or sets the reference string to a definition.
-    /// </summary>
-    [JsonProperty("$ref")] public string? Reference { get; set; }
-
-    /// <summary>
-    /// Gets or sets a short description of the response.
-    /// </summary>
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Gets or sets a list of headers that are sent with the response.
-    /// </summary>
-    public SwaggerDocumentHeaders? Headers { get; set; }
-
-    /// <summary>
-    /// Gets or sets a definition of the response structure.
-    /// </summary>
-    public SwaggerDocumentSchema? Schema { get; set; }
-
-    /// <summary>
-    /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
-    /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
-}
-
-/// <summary>
-/// Defines the list of headers that can be sent as part of a response
-/// </summary>
-public class SwaggerDocumentHeaders : Dictionary<string, SwaggerDocumentHeader>
-{
-}
-
-/// <summary>
-/// Defines the input and output data types.
-/// </summary>
-public class SwaggerDocumentSchema
-{
-    /// <summary>
-    /// Gets or sets the reference string to a definition.
-    /// </summary>
-    [JsonProperty("$ref")] public string? Reference { get; set; }
-
-    /// <summary>
-    /// Gets or sets the type of the object.
-    /// </summary>
-    public string? Type { get; set; }
-
-    /// <summary>
-    /// Gets or sets the extending format for the <see cref="Type"/>.
-    /// </summary>
-    public string? Format { get; set; }
-
-    /// <summary>
-    /// Gets or sets the type of items in the array if the <see cref="Type"/> is <b>array</b>.
-    /// </summary>
-    public SwaggerDocumentSchema? Items { get; set; }
-
-    /// <summary>
-    /// Gets or sets the properties of an item.
-    /// </summary>
-    public Dictionary<string, SwaggerDocumentSchema>? Properties { get; set; }
-
-    /// <summary>
-    /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
-    /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
-}
-
-/// <summary>
-/// Defines the details of a parameter of a single operation.
-/// </summary>
-public class SwaggerDocumentParameter
+public class SwaggerDocumentProperty
 {
     /// <summary>
     /// Gets or sets the reference string to a definition.
     /// </summary>
-    [JsonProperty("$ref")] public string? Reference { get; set; }
-
-    /// <summary>
-    /// Gets or sets the name of the parameter.
-    /// </summary>
-    public string? Name { get; set; }
-
-    /// <summary>
-    /// Gets or sets the location of the parameter.
-    /// </summary>
-    public string? In { get; set; }
-
-    /// <summary>
-    /// Gets or sets the brief description of the parameter.
-    /// </summary>
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the parameter is mandatory.
-    /// </summary>
-    public bool Required { get; set; } = false;
-
-    /// <summary>
-    /// Gets or sets the type of the parameter.
-    /// </summary>
-    public string? Type { get; set; }
-
-    /// <summary>
-    /// Gets or sets the extending format for the <see cref="Type"/>.
-    /// </summary>
-    public string? Format { get; set; }
-
-    /// <summary>
-    /// Gets or sets the type of items in the array if the <see cref="Type"/> is <b>array</b>.
-    /// </summary>
-    public SwaggerDocumentSchema? Items { get; set; }
-
-    /// <summary>
-    /// Gets or sets the properties of an item.
-    /// </summary>
-    public Dictionary<string, SwaggerDocumentSchema>? Properties { get; set; }
+    [JsonProperty("$ref", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Reference { get; set; }
 
     /// <summary>
     /// Gets or sets a definition of the parameter structure.
     /// </summary>
-    public SwaggerDocumentSchema? Schema { get; set; }
+    [JsonProperty("schema", NullValueHandling = NullValueHandling.Ignore)]
+    public SwaggerDocumentProperty? Schema { get; set; }
 
     /// <summary>
-    /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
+    /// Gets or sets the type of items in the array if the type is <b>array</b>.
     /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
-}
-
-public class SwaggerDocumentHeader
-{
-    /// <summary>
-    /// Gets or sets a short description of the header.
-    /// </summary>
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Gets or sets the type of the object.
-    /// </summary>
-    public string? Type { get; set; }
-
-    /// <summary>
-    /// Gets or sets the extending format for the <see cref="Type"/>.
-    /// </summary>
-    public string? Format { get; set; }
-
-    /// <summary>
-    /// Gets or sets the type of items in the array if the <see cref="Type"/> is <b>array</b>.
-    /// </summary>
-    public SwaggerDocumentSchema? Items { get; set; }
+    [JsonProperty("items", NullValueHandling = NullValueHandling.Ignore)]
+    public SwaggerDocumentProperty? Items { get; set; }
 
     /// <summary>
     /// Gets or sets the properties of an item.
     /// </summary>
-    public Dictionary<string, SwaggerDocumentSchema>? Properties { get; set; }
+    [JsonProperty("properties", NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string, SwaggerDocumentProperty>? Properties { get; set; }
 
     /// <summary>
     /// Gets or sets the additional properties that are not covered by the defined Swagger properties.
     /// </summary>
-    [JsonExtensionData]
-    public Dictionary<string, object>? AdditionalProperties { get; set; }
+    [JsonIgnore]
+    public Dictionary<string, SwaggerDocumentProperty>? AdditionalProperties { get; set; }
+
+    [JsonExtensionData] public Dictionary<string, JToken>? JTokenProperties { get; set; }
+
+    private static SwaggerDocumentProperty ToSwaggerDocumentProperty(JToken? jsonObject)
+    {
+        if (jsonObject == null)
+        {
+            return new SwaggerDocumentProperty();
+        }
+
+        using StringWriter sw = new StringWriter(CultureInfo.InvariantCulture);
+        JsonTextWriter jw = new JsonTextWriter(sw);
+        jsonObject.WriteTo(jw);
+        var json = sw.ToString();
+        return JsonConvert.DeserializeObject<SwaggerDocumentProperty>(json, JsonFile.Settings) ?? new SwaggerDocumentProperty();
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        var objectTokens = JTokenProperties?.Where(x => x.Value is JObject).ToList();
+
+        if (objectTokens == null || !objectTokens.Any())
+        {
+            return;
+        }
+
+        this.AdditionalProperties = objectTokens.ToDictionary(
+            x => x.Key,
+            x => ToSwaggerDocumentProperty(x.Value as JObject));
+
+        this.JTokenProperties.RemoveRange(objectTokens);
+    }
+
+    [OnSerializing]
+    private void OnSerializing(StreamingContext context)
+    {
+        var additionalProperties = AdditionalProperties?.ToDictionary(
+            x => x.Key,
+            x => JToken.FromObject(x.Value));
+
+        if (additionalProperties == null)
+        {
+            return;
+        }
+
+        JTokenProperties.AddRange(additionalProperties);
+    }
 }


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Alteration to the JSON.NET serializer settings to ensure that keys for pre-determined objects are not altered during the output serialization.

## PR checklist

- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
