### PR TITLE
feat: add YAML format support for Swagger V2 documents

### DIFF
--- a/docs/feature-plan-v3-yaml-support.md
+++ b/docs/feature-plan-v3-yaml-support.md
@@ -1,0 +1,320 @@
+# Feature Plan: OpenAPI V3 + YAML Support
+
+## Summary
+
+Extend swagger-merge to support merging OpenAPI V3 (3.x) specification files in addition to Swagger V2, and support both JSON and YAML file formats for input and output.
+
+## Current State
+
+- The tool merges **Swagger V2 JSON files only**
+- The `SwaggerDocument` model maps 1:1 to V2 fields (`host`, `basePath`, `schemes`, `definitions`, `securityDefinitions`)
+- Definition resolution hardcodes `#/definitions/` ref paths
+- `ISwaggerDocumentHandler` is JSON-only (`LoadFromJson`, `LoadFromFilePathAsync` reads JSON)
+- Output config (`SwaggerOutputConfiguration`) has V2-only fields: `Host`, `BasePath`, `Schemes`, `SecurityDefinitions`
+- All serialization uses `System.Text.Json` with source-generated contexts for AOT compatibility
+
+## V2 vs V3 Structural Differences
+
+| Swagger V2 (current) | OpenAPI V3 (needed) |
+|---|---|
+| `swagger: "2.0"` | `openapi: "3.x.x"` |
+| `host` + `basePath` + `schemes` | `servers` array |
+| `definitions` | `components.schemas` |
+| `securityDefinitions` | `components.securitySchemes` |
+| `parameters` (top-level) | `components.parameters` |
+| `responses` (top-level) | `components.responses` |
+| `produces` / `consumes` (doc + operation) | Per-operation `requestBody` + `content` media types |
+| `$ref: "#/definitions/Foo"` | `$ref: "#/components/schemas/Foo"` |
+
+## Design Approach
+
+### Strategy: Separate V2 and V3 Document Models with a Shared Merge Abstraction
+
+Rather than a unified document model (which would be fragile and hard to maintain), use separate strongly-typed models for V2 and V3, with a common interface for the merge handler to work against.
+
+### Key Design Decisions
+
+1. **Separate document models** - `SwaggerDocument` (V2, existing) and `OpenApiDocument` (V3, new). Each has its own serialization context. This keeps the models clean and avoids conditional logic.
+
+2. **Spec version detection** - On load, peek at the document to determine version (`swagger: "2.0"` vs `openapi: "3.x.x"`) and deserialize to the correct model.
+
+3. **Format detection** - Detect JSON vs YAML by file extension (`.json` vs `.yaml`/`.yml`) and content sniffing (leading `{` for JSON).
+
+4. **YAML library** - Add `YamlDotNet` for YAML parsing. Convert YAML to an intermediate representation, then serialize to/from the typed models. Validate AOT compatibility.
+
+5. **Merge handler per version** - `SwaggerMergeHandler` (V2, existing) and `OpenApiMergeHandler` (V3, new), both implementing a common interface. The correct handler is selected based on the detected spec version of the inputs.
+
+6. **No cross-version merging** - V2 inputs merge to V2 output; V3 inputs merge to V3 output. Mixing V2 and V3 inputs is an error. (Cross-version conversion could be a future feature.)
+
+7. **Configuration evolution** - Extend the configuration model to support both V2 and V3 output options, with the output config shape determined by the spec version.
+
+---
+
+## Work Breakdown
+
+### Phase 1: Foundation - Format Detection + YAML Support
+
+Add the ability to load and save documents in both JSON and YAML formats, with automatic format detection.
+
+#### WI-1: Add YAML serialization support
+
+**Scope**: SDK project
+
+- Add `YamlDotNet` NuGet package to `SwaggerMerge.SDK.csproj`
+- Validate AOT compatibility of YamlDotNet (check if it works with NativeAOT publish)
+- If YamlDotNet is not AOT-compatible, evaluate alternatives or document the limitation
+
+#### WI-2: Extend document handler for format detection
+
+**Scope**: SDK project
+
+- Rename/evolve `ISwaggerDocumentHandler` to support both formats:
+  - `LoadFromFilePathAsync(string filePath)` - detect format from extension
+  - `LoadFromContent(string content, DocumentFormat format)` - explicit format
+  - `SaveToPathAsync(SwaggerDocument document, string filePath, DocumentFormat format)` - save in specified format
+- Add `DocumentFormat` enum: `Json`, `Yaml`
+- Implement format detection: `.json` = JSON, `.yaml`/`.yml` = YAML, content sniff as fallback
+- Implement YAML deserialization to `SwaggerDocument` (V2 model, reusing existing types)
+- Implement YAML serialization from `SwaggerDocument`
+- Update `SwaggerDocumentHandler` implementation
+
+#### WI-3: Add YAML test documents and tests
+
+**Scope**: Test project
+
+- Create YAML versions of existing test Swagger documents (`pet.swagger.yaml`, etc.)
+- Add tests for YAML load, save, and round-trip
+- Add tests for format detection logic
+- Add tests for JSON-to-YAML and YAML-to-JSON conversion round-trips
+
+#### WI-4: Update CLI for format-aware I/O
+
+**Scope**: CLI project
+
+- Update `SwaggerMergeConfigurationFileHandler` to detect input file formats
+- Support YAML config files in addition to JSON config files (optional, stretch goal)
+- Update output handling to respect the output file extension for format selection
+- Add `--format` CLI option or auto-detect from output file extension
+
+---
+
+### Phase 2: OpenAPI V3 Document Model
+
+Build the V3 document model and serialization, parallel to the existing V2 model.
+
+#### WI-5: Create OpenAPI V3 document model
+
+**Scope**: SDK project, new `Document/V3/` directory
+
+- Create `OpenApiDocument` class with V3 fields:
+  - `openapi` (version string, e.g., "3.0.3", "3.1.0")
+  - `info` (reuse or create V3-compatible info model)
+  - `servers` (list of `OpenApiServer` with `url`, `description`, `variables`)
+  - `paths` (similar structure to V2 but with V3 operation model)
+  - `components` (`OpenApiComponents` with `schemas`, `responses`, `parameters`, `examples`, `requestBodies`, `headers`, `securitySchemes`, `links`, `callbacks`)
+  - `security` (list of security requirements)
+  - `tags` (list of tag objects)
+  - `externalDocs`
+- Create V3-specific sub-models:
+  - `OpenApiOperation` - includes `requestBody`, `callbacks`, `servers`
+  - `OpenApiRequestBody` - `content` map of media types
+  - `OpenApiMediaType` - `schema`, `examples`, `encoding`
+  - `OpenApiServer` - `url`, `description`, `variables`
+  - `OpenApiComponents` - container for all reusable objects
+- Use `[JsonExtensionData]` for forward compatibility (same pattern as V2)
+
+#### WI-6: Add V3 JSON serialization context
+
+**Scope**: SDK project
+
+- Create `OpenApiDocumentJsonSerializerContext` with source-generated contexts for all V3 types
+- Create `OpenApiDocumentJson` with shared serializer options
+- Ensure AOT compatibility
+
+#### WI-7: Add V3 YAML serialization
+
+**Scope**: SDK project
+
+- Implement YAML serialization/deserialization for V3 model types
+- Reuse the YAML infrastructure from Phase 1
+
+#### WI-8: Implement spec version detection
+
+**Scope**: SDK project
+
+- Create a `SpecVersionDetector` that peeks at document content to determine:
+  - V2: presence of `"swagger"` key with value `"2.0"`
+  - V3: presence of `"openapi"` key with value starting with `"3."`
+- Integrate into the document handler to auto-select the correct model for deserialization
+- Return a `SpecVersion` enum: `SwaggerV2`, `OpenApiV3`
+
+#### WI-9: Add V3 test documents and serialization tests
+
+**Scope**: Test project
+
+- Create V3 versions of test API documents (pet, store, todo, user) in both JSON and YAML
+- Add tests for V3 document load, save, round-trip in both formats
+- Add tests for spec version detection
+
+---
+
+### Phase 3: V3 Merge Logic
+
+Implement the merge handler for OpenAPI V3 documents.
+
+#### WI-10: Create V3 merge handler
+
+**Scope**: SDK project
+
+- Create `OpenApiMergeHandler` (or extend as partial classes, matching V2 pattern):
+  - `OpenApiMergeHandler.cs` - main merge orchestrator
+  - `OpenApiMergeHandler.Inputs.cs` - path transforms, title appending (same concepts as V2)
+  - `OpenApiMergeHandler.Components.cs` - component schema resolution (replaces `Definitions.cs` pattern)
+- Merge logic for V3-specific fields:
+  - `paths` - same concept as V2, with path transforms and operation exclusions
+  - `components.schemas` - union of all input schemas (equivalent of V2 `definitions`)
+  - `components.parameters` - merge reusable parameters
+  - `components.responses` - merge reusable responses
+  - `components.securitySchemes` - merge security schemes
+- `$ref` resolution uses `#/components/schemas/` instead of `#/definitions/`
+- Unused component pruning (equivalent of V2 definition pruning)
+
+#### WI-11: Create V3 merge configuration
+
+**Scope**: SDK project
+
+- Create `OpenApiOutputConfiguration` with V3 fields:
+  - `Servers` (list of server objects, replaces `Host`/`BasePath`/`Schemes`)
+  - `Components.SecuritySchemes` (replaces `SecurityDefinitions`)
+  - `Security`
+  - `Info` (title, version)
+- Create `OpenApiMergeConfiguration` or extend existing to support V3 output
+- Alternatively, use a polymorphic config model that supports both V2 and V3
+
+#### WI-12: Add V3 merge tests
+
+**Scope**: Test project
+
+- Port all existing V2 merge tests to V3 equivalents:
+  - Multi-document path merging
+  - Title appending
+  - Path transforms (StripStart, Prepend)
+  - Component schema merging (equivalent of definition merging)
+  - Server assignment
+  - Operation exclusions with component pruning
+- Add V3-specific tests:
+  - Components merging (parameters, responses, security schemes)
+  - Server array handling
+
+---
+
+### Phase 4: Unified Handler Selection + CLI Integration
+
+Wire everything together so the tool auto-selects the correct handler based on input spec version.
+
+#### WI-13: Implement merge handler routing
+
+**Scope**: SDK project
+
+- Create a unified entry point / factory that:
+  - Inspects the spec version of input documents
+  - Validates all inputs are the same version (error if mixed)
+  - Routes to `SwaggerMergeHandler` (V2) or `OpenApiMergeHandler` (V3)
+- Update `ISwaggerMergeHandler` or create a new unified interface
+
+#### WI-14: Update CLI for V3 support
+
+**Scope**: CLI project
+
+- Update config file model to support V3 output options (`servers` instead of `host`/`basePath`/`schemes`)
+- Update `SwaggerMergeConfigurationFileHandler` to detect V3 config and convert appropriately
+- Update DI registration to include V3 handler
+- Update validation logic for V3-specific config requirements
+
+#### WI-15: Update CLI config schema
+
+**Scope**: CLI project + documentation
+
+- Design the config file format that supports both V2 and V3:
+  ```json
+  {
+    "inputs": [...],
+    "output": {
+      "info": { "title": "...", "version": "..." },
+      // V2 options (used when inputs are V2):
+      "host": "...",
+      "basePath": "...",
+      "schemes": ["https"],
+      // V3 options (used when inputs are V3):
+      "servers": [{ "url": "https://api.example.com" }]
+    }
+  }
+  ```
+- Validate that V2 and V3 output options are not mixed
+
+#### WI-16: Add end-to-end integration tests
+
+**Scope**: Test project
+
+- V2 JSON merge (existing, verify still passes)
+- V2 YAML merge (new)
+- V3 JSON merge (new)
+- V3 YAML merge (new)
+- Mixed format inputs (V3 JSON + V3 YAML = valid)
+- Mixed version inputs (V2 + V3 = error)
+- Output format respects file extension
+
+---
+
+### Phase 5: AOT Compatibility + Documentation
+
+#### WI-17: Update AOT compatibility tests
+
+**Scope**: AOT test project
+
+- Add V3 document types to AOT test app
+- Add V3 merge smoke test
+- Add YAML round-trip in AOT context
+- Verify zero IL warnings with new types
+
+#### WI-18: Update documentation
+
+**Scope**: Root + project READMEs
+
+- Update root `README.md` to document V3 and YAML support
+- Update SDK `README.md` with V3 usage examples
+- Update CLI `README.md` with V3 config examples
+- Add migration guide for existing V2-only users (no breaking changes expected)
+- Document config file format for both V2 and V3
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| YamlDotNet not AOT-compatible | YAML support may not work with NativeAOT | Test early in Phase 1; evaluate alternatives (e.g., SharpYaml) or accept YAML as non-AOT |
+| V3 spec complexity | V3 has significantly more features than V2 (callbacks, links, webhooks in 3.1) | Start with core V3 features (servers, components, paths); defer advanced features |
+| Breaking changes to public API | SDK consumers may need code changes | Design V3 support as additive; keep existing V2 interfaces intact |
+| YAML serialization fidelity | YAML round-trip may lose formatting or comments | Use standard YAML libraries; document that comments are not preserved |
+| Mixed version detection edge cases | Malformed documents may not be detectable | Fail fast with clear error messages; require explicit version in config as fallback |
+
+## Implementation Order
+
+The phases are designed to be incremental and independently testable:
+
+1. **Phase 1** (YAML) can ship independently as a useful feature even without V3
+2. **Phase 2** (V3 model) is foundational for Phase 3
+3. **Phase 3** (V3 merge) depends on Phase 2
+4. **Phase 4** (integration) ties everything together
+5. **Phase 5** (AOT + docs) finalizes the release
+
+Each phase can be a separate PR or set of PRs for manageable review.
+
+## Out of Scope (Future Work)
+
+- **V2-to-V3 conversion** - Automatically converting V2 documents to V3 before merging
+- **OpenAPI 3.1 specific features** - Webhooks, JSON Schema alignment (3.1 changes)
+- **YAML config files** - Config file itself in YAML format (stretch goal in Phase 1)
+- **Schema validation** - Validating input documents against the OpenAPI specification schema
+- **Non-JSON/YAML formats** - No plans for other formats

--- a/src/SwaggerMerge.SDK/Document/DocumentFormat.cs
+++ b/src/SwaggerMerge.SDK/Document/DocumentFormat.cs
@@ -1,0 +1,17 @@
+namespace SwaggerMerge.Document;
+
+/// <summary>
+/// Defines the supported document formats for Swagger/OpenAPI files.
+/// </summary>
+public enum DocumentFormat
+{
+    /// <summary>
+    /// JSON format.
+    /// </summary>
+    Json,
+
+    /// <summary>
+    /// YAML format.
+    /// </summary>
+    Yaml
+}

--- a/src/SwaggerMerge.SDK/Document/IDocumentFormatHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/IDocumentFormatHandler.cs
@@ -1,0 +1,26 @@
+namespace SwaggerMerge.Document;
+
+/// <summary>
+/// Defines an interface for serializing and deserializing <see cref="SwaggerDocument"/> objects in a specific format.
+/// </summary>
+public interface IDocumentFormatHandler
+{
+    /// <summary>
+    /// Gets the document format this handler supports.
+    /// </summary>
+    DocumentFormat Format { get; }
+
+    /// <summary>
+    /// Deserializes a <see cref="SwaggerDocument"/> from the specified content string.
+    /// </summary>
+    /// <param name="content">The string content representing the Swagger document.</param>
+    /// <returns>A <see cref="SwaggerDocument"/> representing the content.</returns>
+    SwaggerDocument Deserialize(string content);
+
+    /// <summary>
+    /// Serializes a <see cref="SwaggerDocument"/> to a string in this handler's format.
+    /// </summary>
+    /// <param name="document">The document to serialize.</param>
+    /// <returns>A string representation of the document.</returns>
+    string Serialize(SwaggerDocument document);
+}

--- a/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
@@ -56,9 +56,11 @@ public interface ISwaggerDocumentHandler
         {
             ".yaml" or ".yml" => DocumentFormat.Yaml,
             ".json" => DocumentFormat.Json,
-            _ => content != null
-                ? (content.TrimStart().StartsWith('{') ? DocumentFormat.Json : DocumentFormat.Yaml)
-                : DocumentFormat.Json
+            _ when !string.IsNullOrWhiteSpace(content) =>
+                content.TrimStart().StartsWith('{') || content.TrimStart().StartsWith('[')
+                    ? DocumentFormat.Json
+                    : DocumentFormat.Yaml,
+            _ => DocumentFormat.Json
         };
     }
 }

--- a/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
@@ -56,11 +56,35 @@ public interface ISwaggerDocumentHandler
         {
             ".yaml" or ".yml" => DocumentFormat.Yaml,
             ".json" => DocumentFormat.Json,
-            _ when !string.IsNullOrWhiteSpace(content) =>
-                content.TrimStart().StartsWith('{') || content.TrimStart().StartsWith('[')
-                    ? DocumentFormat.Json
-                    : DocumentFormat.Yaml,
+            _ when !string.IsNullOrWhiteSpace(content) => SniffContentFormat(content),
             _ => DocumentFormat.Json
         };
+    }
+
+    private static DocumentFormat SniffContentFormat(string content)
+    {
+        var trimmed = content.TrimStart();
+        if (trimmed.Length == 0)
+        {
+            return DocumentFormat.Json;
+        }
+
+        // If content starts with '{' or '[', it could be JSON or YAML flow-style.
+        // Attempt a lightweight JSON parse to distinguish.
+        if (trimmed[0] is '{' or '[')
+        {
+            try
+            {
+                System.Text.Json.JsonDocument.Parse(content).Dispose();
+                return DocumentFormat.Json;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Not valid JSON (e.g. YAML flow-style with unquoted keys); treat as YAML.
+                return DocumentFormat.Yaml;
+            }
+        }
+
+        return DocumentFormat.Yaml;
     }
 }

--- a/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/ISwaggerDocumentHandler.cs
@@ -6,10 +6,10 @@ namespace SwaggerMerge.Document;
 public interface ISwaggerDocumentHandler
 {
     /// <summary>
-    /// Loads a <see cref="SwaggerDocument"/> from the specified path.
+    /// Loads a <see cref="SwaggerDocument"/> from the specified path, auto-detecting format from the file extension.
     /// </summary>
-    /// <param name="filePath">The file path to the Swagger JSON document.</param>
-    /// <returns>A <see cref="SwaggerDocument"/> representing the JSON file.</returns>
+    /// <param name="filePath">The file path to the Swagger document.</param>
+    /// <returns>A <see cref="SwaggerDocument"/> representing the file.</returns>
     Task<SwaggerDocument> LoadFromFilePathAsync(string filePath);
 
     /// <summary>
@@ -20,10 +20,45 @@ public interface ISwaggerDocumentHandler
     SwaggerDocument LoadFromJson(string swaggerJson);
 
     /// <summary>
-    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path.
+    /// Loads a <see cref="SwaggerDocument"/> from the specified YAML string representing the document.
+    /// </summary>
+    /// <param name="swaggerYaml">The <see cref="string"/> representing the Swagger document YAML.</param>
+    /// <returns>A <see cref="SwaggerDocument"/> representing the YAML content.</returns>
+    SwaggerDocument LoadFromYaml(string swaggerYaml);
+
+    /// <summary>
+    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path, auto-detecting format from the file extension.
     /// </summary>
     /// <param name="document">The document to save.</param>
-    /// <param name="filePath">The file path to the location where the Swagger JSON file should be saved.</param>
+    /// <param name="filePath">The file path to the location where the Swagger file should be saved.</param>
     /// <returns>An asynchronous operation.</returns>
     Task SaveToPathAsync(SwaggerDocument document, string filePath);
+
+    /// <summary>
+    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path in the specified format.
+    /// </summary>
+    /// <param name="document">The document to save.</param>
+    /// <param name="filePath">The file path to the location where the Swagger file should be saved.</param>
+    /// <param name="format">The format to save the document in.</param>
+    /// <returns>An asynchronous operation.</returns>
+    Task SaveToPathAsync(SwaggerDocument document, string filePath, DocumentFormat format);
+
+    /// <summary>
+    /// Detects the document format from the file extension, falling back to content sniffing.
+    /// </summary>
+    /// <param name="filePath">The file path to detect format from.</param>
+    /// <param name="content">Optional content to sniff when the extension is ambiguous.</param>
+    /// <returns>The detected <see cref="DocumentFormat"/>.</returns>
+    static DocumentFormat DetectFormat(string filePath, string? content = null)
+    {
+        var extension = Path.GetExtension(filePath)?.ToLowerInvariant();
+        return extension switch
+        {
+            ".yaml" or ".yml" => DocumentFormat.Yaml,
+            ".json" => DocumentFormat.Json,
+            _ => content != null
+                ? (content.TrimStart().StartsWith('{') ? DocumentFormat.Json : DocumentFormat.Yaml)
+                : DocumentFormat.Json
+        };
+    }
 }

--- a/src/SwaggerMerge.SDK/Document/JsonDocumentFormatHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/JsonDocumentFormatHandler.cs
@@ -1,0 +1,27 @@
+namespace SwaggerMerge.Document;
+
+using System.Text.Json;
+
+/// <summary>
+/// Handles serialization and deserialization of <see cref="SwaggerDocument"/> objects in JSON format.
+/// </summary>
+public class JsonDocumentFormatHandler : IDocumentFormatHandler
+{
+    /// <inheritdoc/>
+    public DocumentFormat Format => DocumentFormat.Json;
+
+    /// <inheritdoc/>
+    public SwaggerDocument Deserialize(string content)
+    {
+        var deserializedContent =
+            JsonSerializer.Deserialize(content, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
+        return deserializedContent ?? throw new InvalidOperationException(
+            "The Swagger document JSON could not be loaded correctly as the format is not as expected.");
+    }
+
+    /// <inheritdoc/>
+    public string Serialize(SwaggerDocument document)
+    {
+        return JsonSerializer.Serialize(document, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
+    }
+}

--- a/src/SwaggerMerge.SDK/Document/SwaggerDocumentHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/SwaggerDocumentHandler.cs
@@ -1,7 +1,10 @@
 namespace SwaggerMerge.Document;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using YamlDotNet.Serialization;
 
 /// <summary>
 /// Defines an implementation for handling <see cref="SwaggerDocument"/> objects.
@@ -9,14 +12,15 @@ using System.Text.Json;
 public class SwaggerDocumentHandler : ISwaggerDocumentHandler
 {
     /// <summary>
-    /// Loads a <see cref="SwaggerDocument"/> from the specified path.
+    /// Loads a <see cref="SwaggerDocument"/> from the specified path, auto-detecting format from the file extension.
     /// </summary>
-    /// <param name="filePath">The file path to the Swagger JSON document.</param>
-    /// <returns>A <see cref="SwaggerDocument"/> representing the JSON file.</returns>
+    /// <param name="filePath">The file path to the Swagger document.</param>
+    /// <returns>A <see cref="SwaggerDocument"/> representing the file.</returns>
     public async Task<SwaggerDocument> LoadFromFilePathAsync(string filePath)
     {
-        var swaggerJson = await ReadAllTextAsync(filePath);
-        return this.LoadFromJson(swaggerJson);
+        var content = await ReadAllTextAsync(filePath);
+        var format = ISwaggerDocumentHandler.DetectFormat(filePath, content);
+        return format == DocumentFormat.Yaml ? this.LoadFromYaml(content) : this.LoadFromJson(content);
     }
 
     /// <summary>
@@ -33,15 +37,92 @@ public class SwaggerDocumentHandler : ISwaggerDocumentHandler
     }
 
     /// <summary>
-    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path.
+    /// Loads a <see cref="SwaggerDocument"/> from the specified YAML string representing the document.
+    /// </summary>
+    /// <param name="swaggerYaml">The <see cref="string"/> representing the Swagger document YAML.</param>
+    /// <returns>A <see cref="SwaggerDocument"/> representing the YAML content.</returns>
+    public SwaggerDocument LoadFromYaml(string swaggerYaml)
+    {
+        var json = ConvertYamlToJson(swaggerYaml);
+        return this.LoadFromJson(json);
+    }
+
+    /// <summary>
+    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path, auto-detecting format from the file extension.
     /// </summary>
     /// <param name="document">The document to save.</param>
-    /// <param name="filePath">The file path to the location where the Swagger JSON file should be saved.</param>
+    /// <param name="filePath">The file path to the location where the Swagger file should be saved.</param>
     /// <returns>An asynchronous operation.</returns>
-    public async Task SaveToPathAsync(SwaggerDocument document, string filePath)
+    public Task SaveToPathAsync(SwaggerDocument document, string filePath)
     {
-        var swaggerJson = JsonSerializer.Serialize(document, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
-        await WriteAllTextAsync(swaggerJson, filePath);
+        var format = ISwaggerDocumentHandler.DetectFormat(filePath);
+        return this.SaveToPathAsync(document, filePath, format);
+    }
+
+    /// <summary>
+    /// Saves the specified <see cref="SwaggerDocument"/> to the specified path in the specified format.
+    /// </summary>
+    /// <param name="document">The document to save.</param>
+    /// <param name="filePath">The file path to the location where the Swagger file should be saved.</param>
+    /// <param name="format">The format to save the document in.</param>
+    /// <returns>An asynchronous operation.</returns>
+    public async Task SaveToPathAsync(SwaggerDocument document, string filePath, DocumentFormat format)
+    {
+        var json = JsonSerializer.Serialize(document, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
+
+        if (format == DocumentFormat.Yaml)
+        {
+            var yaml = ConvertJsonToYaml(json);
+            await WriteAllTextAsync(yaml, filePath);
+        }
+        else
+        {
+            await WriteAllTextAsync(json, filePath);
+        }
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "YamlDotNet reflection builders are used only as an intermediary YAML<->JSON converter. The actual document model uses AOT-compatible System.Text.Json source generation.")]
+    private static string ConvertYamlToJson(string yaml)
+    {
+        var deserializer = new DeserializerBuilder().Build();
+        var yamlObject = deserializer.Deserialize<object>(yaml);
+        var serializer = new SerializerBuilder()
+            .JsonCompatible()
+            .Build();
+        return serializer.Serialize(yamlObject);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "YamlDotNet reflection builders are used only as an intermediary JSON->YAML converter. The actual document model uses AOT-compatible System.Text.Json source generation.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JsonNode deserialization does not require type metadata.")]
+    private static string ConvertJsonToYaml(string json)
+    {
+        var jsonNode = JsonNode.Parse(json);
+        var nativeObject = ConvertJsonNodeToNative(jsonNode);
+        var serializer = new SerializerBuilder()
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+            .Build();
+        return serializer.Serialize(nativeObject!);
+    }
+
+    private static object? ConvertJsonNodeToNative(JsonNode? node)
+    {
+        return node switch
+        {
+            JsonObject obj => obj.ToDictionary(kvp => kvp.Key, kvp => ConvertJsonNodeToNative(kvp.Value)),
+            JsonArray arr => arr.Select(ConvertJsonNodeToNative).ToList(),
+            JsonValue val => ConvertJsonValueToNative(val),
+            null => null,
+            _ => node.ToString()
+        };
+    }
+
+    private static object? ConvertJsonValueToNative(JsonValue value)
+    {
+        if (value.TryGetValue<bool>(out var boolVal)) return boolVal;
+        if (value.TryGetValue<long>(out var longVal)) return longVal;
+        if (value.TryGetValue<double>(out var doubleVal)) return doubleVal;
+        if (value.TryGetValue<string>(out var strVal)) return strVal;
+        return value.ToString();
     }
 
     private static async Task<string> ReadAllTextAsync(string filePath)

--- a/src/SwaggerMerge.SDK/Document/SwaggerDocumentHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/SwaggerDocumentHandler.cs
@@ -1,16 +1,16 @@
 namespace SwaggerMerge.Document;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using YamlDotNet.Serialization;
 
 /// <summary>
 /// Defines an implementation for handling <see cref="SwaggerDocument"/> objects.
+/// Delegates serialization to format-specific <see cref="IDocumentFormatHandler"/> implementations.
 /// </summary>
 public class SwaggerDocumentHandler : ISwaggerDocumentHandler
 {
+    private readonly IDocumentFormatHandler _jsonHandler = new JsonDocumentFormatHandler();
+    private readonly IDocumentFormatHandler _yamlHandler = new YamlDocumentFormatHandler();
+
     /// <summary>
     /// Loads a <see cref="SwaggerDocument"/> from the specified path, auto-detecting format from the file extension.
     /// </summary>
@@ -20,7 +20,7 @@ public class SwaggerDocumentHandler : ISwaggerDocumentHandler
     {
         var content = await ReadAllTextAsync(filePath);
         var format = ISwaggerDocumentHandler.DetectFormat(filePath, content);
-        return format == DocumentFormat.Yaml ? this.LoadFromYaml(content) : this.LoadFromJson(content);
+        return GetHandler(format).Deserialize(content);
     }
 
     /// <summary>
@@ -30,10 +30,7 @@ public class SwaggerDocumentHandler : ISwaggerDocumentHandler
     /// <returns>A <see cref="SwaggerDocument"/> representing the JSON content.</returns>
     public SwaggerDocument LoadFromJson(string swaggerJson)
     {
-        var deserializedContent =
-            JsonSerializer.Deserialize(swaggerJson, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
-        return deserializedContent ?? throw new InvalidOperationException(
-            "The Swagger document JSON could not be loaded correctly as the format is not as expected.");
+        return _jsonHandler.Deserialize(swaggerJson);
     }
 
     /// <summary>
@@ -43,8 +40,7 @@ public class SwaggerDocumentHandler : ISwaggerDocumentHandler
     /// <returns>A <see cref="SwaggerDocument"/> representing the YAML content.</returns>
     public SwaggerDocument LoadFromYaml(string swaggerYaml)
     {
-        var json = ConvertYamlToJson(swaggerYaml);
-        return this.LoadFromJson(json);
+        return _yamlHandler.Deserialize(swaggerYaml);
     }
 
     /// <summary>
@@ -68,62 +64,12 @@ public class SwaggerDocumentHandler : ISwaggerDocumentHandler
     /// <returns>An asynchronous operation.</returns>
     public async Task SaveToPathAsync(SwaggerDocument document, string filePath, DocumentFormat format)
     {
-        var json = JsonSerializer.Serialize(document, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument);
-
-        if (format == DocumentFormat.Yaml)
-        {
-            var yaml = ConvertJsonToYaml(json);
-            await WriteAllTextAsync(yaml, filePath);
-        }
-        else
-        {
-            await WriteAllTextAsync(json, filePath);
-        }
+        var content = GetHandler(format).Serialize(document);
+        await WriteAllTextAsync(content, filePath);
     }
 
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "YamlDotNet reflection builders are used only as an intermediary YAML<->JSON converter. The actual document model uses AOT-compatible System.Text.Json source generation.")]
-    private static string ConvertYamlToJson(string yaml)
-    {
-        var deserializer = new DeserializerBuilder().Build();
-        var yamlObject = deserializer.Deserialize<object>(yaml);
-        var serializer = new SerializerBuilder()
-            .JsonCompatible()
-            .Build();
-        return serializer.Serialize(yamlObject);
-    }
-
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "YamlDotNet reflection builders are used only as an intermediary JSON->YAML converter. The actual document model uses AOT-compatible System.Text.Json source generation.")]
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JsonNode deserialization does not require type metadata.")]
-    private static string ConvertJsonToYaml(string json)
-    {
-        var jsonNode = JsonNode.Parse(json);
-        var nativeObject = ConvertJsonNodeToNative(jsonNode);
-        var serializer = new SerializerBuilder()
-            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
-            .Build();
-        return serializer.Serialize(nativeObject!);
-    }
-
-    private static object? ConvertJsonNodeToNative(JsonNode? node)
-    {
-        return node switch
-        {
-            JsonObject obj => obj.ToDictionary(kvp => kvp.Key, kvp => ConvertJsonNodeToNative(kvp.Value)),
-            JsonArray arr => arr.Select(ConvertJsonNodeToNative).ToList(),
-            JsonValue val => ConvertJsonValueToNative(val),
-            null => null,
-            _ => node.ToString()
-        };
-    }
-
-    private static object? ConvertJsonValueToNative(JsonValue value)
-    {
-        if (value.TryGetValue<bool>(out var boolVal)) return boolVal;
-        if (value.TryGetValue<long>(out var longVal)) return longVal;
-        if (value.TryGetValue<double>(out var doubleVal)) return doubleVal;
-        if (value.TryGetValue<string>(out var strVal)) return strVal;
-        return value.ToString();
-    }
+    private IDocumentFormatHandler GetHandler(DocumentFormat format) =>
+        format == DocumentFormat.Yaml ? _yamlHandler : _jsonHandler;
 
     private static async Task<string> ReadAllTextAsync(string filePath)
     {

--- a/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
@@ -58,7 +58,9 @@ public class YamlDocumentFormatHandler : IDocumentFormatHandler
                 writer.WriteStartObject();
                 foreach (var entry in mapping.Children)
                 {
-                    var key = ((YamlScalarNode)entry.Key).Value!;
+                    var key = entry.Key is YamlScalarNode scalarKey
+                        ? scalarKey.Value ?? string.Empty
+                        : entry.Key.ToString();
                     writer.WritePropertyName(key);
                     WriteYamlNodeAsJson(writer, entry.Value);
                 }
@@ -101,24 +103,25 @@ public class YamlDocumentFormatHandler : IDocumentFormatHandler
             return;
         }
 
+        // Only coerce unquoted scalars that are unambiguously typed.
+        // Booleans: true/false (case-insensitive per YAML 1.1/1.2 core schema)
         if (bool.TryParse(value, out var boolVal))
         {
             writer.WriteBooleanValue(boolVal);
             return;
         }
 
-        if (long.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longVal))
+        // Pure integers (no decimal point) are safe to coerce
+        if (long.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longVal)
+            && !value.Contains('.'))
         {
             writer.WriteNumberValue(longVal);
             return;
         }
 
-        if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var doubleVal))
-        {
-            writer.WriteNumberValue(doubleVal);
-            return;
-        }
-
+        // Treat all other scalars as strings to avoid coercing version-like
+        // values (e.g. "2.0") to JSON numbers, which would break fields
+        // defined as strings in the Swagger/OpenAPI specification.
         writer.WriteStringValue(value);
     }
 

--- a/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
@@ -1,0 +1,197 @@
+namespace SwaggerMerge.Document;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+/// <summary>
+/// Handles serialization and deserialization of <see cref="SwaggerDocument"/> objects in YAML format.
+/// Uses AOT-safe YamlDotNet representation model APIs, converting via JSON as an intermediary.
+/// </summary>
+public class YamlDocumentFormatHandler : IDocumentFormatHandler
+{
+    private readonly JsonDocumentFormatHandler _jsonHandler = new();
+
+    /// <inheritdoc/>
+    public DocumentFormat Format => DocumentFormat.Yaml;
+
+    /// <inheritdoc/>
+    public SwaggerDocument Deserialize(string content)
+    {
+        var json = ConvertYamlToJson(content);
+        return _jsonHandler.Deserialize(json);
+    }
+
+    /// <inheritdoc/>
+    public string Serialize(SwaggerDocument document)
+    {
+        var json = _jsonHandler.Serialize(document);
+        return ConvertJsonToYaml(json);
+    }
+
+    private static string ConvertYamlToJson(string yaml)
+    {
+        using var reader = new StringReader(yaml);
+        var yamlStream = new YamlStream();
+        yamlStream.Load(reader);
+
+        if (yamlStream.Documents.Count == 0)
+        {
+            return "{}";
+        }
+
+        using var memoryStream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Indented = true });
+        WriteYamlNodeAsJson(writer, yamlStream.Documents[0].RootNode);
+        writer.Flush();
+        return Encoding.UTF8.GetString(memoryStream.ToArray());
+    }
+
+    private static void WriteYamlNodeAsJson(Utf8JsonWriter writer, YamlNode node)
+    {
+        switch (node)
+        {
+            case YamlMappingNode mapping:
+                writer.WriteStartObject();
+                foreach (var entry in mapping.Children)
+                {
+                    var key = ((YamlScalarNode)entry.Key).Value!;
+                    writer.WritePropertyName(key);
+                    WriteYamlNodeAsJson(writer, entry.Value);
+                }
+                writer.WriteEndObject();
+                break;
+
+            case YamlSequenceNode sequence:
+                writer.WriteStartArray();
+                foreach (var item in sequence.Children)
+                {
+                    WriteYamlNodeAsJson(writer, item);
+                }
+                writer.WriteEndArray();
+                break;
+
+            case YamlScalarNode scalar:
+                WriteYamlScalarAsJson(writer, scalar);
+                break;
+
+            default:
+                writer.WriteNullValue();
+                break;
+        }
+    }
+
+    private static void WriteYamlScalarAsJson(Utf8JsonWriter writer, YamlScalarNode scalar)
+    {
+        var value = scalar.Value;
+
+        if (value == null || value == "~" || value.Equals("null", StringComparison.OrdinalIgnoreCase))
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        // Quoted strings are always strings
+        if (scalar.Style is ScalarStyle.SingleQuoted or ScalarStyle.DoubleQuoted)
+        {
+            writer.WriteStringValue(value);
+            return;
+        }
+
+        if (bool.TryParse(value, out var boolVal))
+        {
+            writer.WriteBooleanValue(boolVal);
+            return;
+        }
+
+        if (long.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var longVal))
+        {
+            writer.WriteNumberValue(longVal);
+            return;
+        }
+
+        if (double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var doubleVal))
+        {
+            writer.WriteNumberValue(doubleVal);
+            return;
+        }
+
+        writer.WriteStringValue(value);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JsonNode deserialization does not require type metadata.")]
+    private static string ConvertJsonToYaml(string json)
+    {
+        var jsonNode = JsonNode.Parse(json);
+        var yamlNode = ConvertJsonNodeToYamlNode(jsonNode);
+
+        var document = new YamlDocument(yamlNode);
+        var yamlStream = new YamlStream(document);
+
+        using var writer = new StringWriter();
+        yamlStream.Save(writer, assignAnchors: false);
+        var yaml = writer.ToString();
+
+        // YamlStream.Save appends "..." document end marker; remove it for cleaner output
+        const string documentEndMarker = "...\r\n";
+        const string documentEndMarkerUnix = "...\n";
+        if (yaml.EndsWith(documentEndMarker, StringComparison.Ordinal))
+        {
+            yaml = yaml[..^documentEndMarker.Length];
+        }
+        else if (yaml.EndsWith(documentEndMarkerUnix, StringComparison.Ordinal))
+        {
+            yaml = yaml[..^documentEndMarkerUnix.Length];
+        }
+
+        return yaml;
+    }
+
+    private static YamlNode ConvertJsonNodeToYamlNode(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                var mapping = new YamlMappingNode();
+                foreach (var kvp in obj)
+                {
+                    mapping.Add(new YamlScalarNode(kvp.Key), ConvertJsonNodeToYamlNode(kvp.Value));
+                }
+                return mapping;
+
+            case JsonArray arr:
+                var sequence = new YamlSequenceNode();
+                foreach (var item in arr)
+                {
+                    sequence.Add(ConvertJsonNodeToYamlNode(item));
+                }
+                return sequence;
+
+            case JsonValue val:
+                return ConvertJsonValueToYamlScalar(val);
+
+            default:
+                return new YamlScalarNode("null") { Style = ScalarStyle.Plain };
+        }
+    }
+
+    private static YamlScalarNode ConvertJsonValueToYamlScalar(JsonValue value)
+    {
+        if (value.TryGetValue<bool>(out var boolVal))
+            return new YamlScalarNode(boolVal ? "true" : "false") { Style = ScalarStyle.Plain };
+
+        if (value.TryGetValue<long>(out var longVal))
+            return new YamlScalarNode(longVal.ToString(System.Globalization.CultureInfo.InvariantCulture)) { Style = ScalarStyle.Plain };
+
+        if (value.TryGetValue<double>(out var doubleVal))
+            return new YamlScalarNode(doubleVal.ToString(System.Globalization.CultureInfo.InvariantCulture)) { Style = ScalarStyle.Plain };
+
+        if (value.TryGetValue<string>(out var strVal))
+            return new YamlScalarNode(strVal) { Style = ScalarStyle.DoubleQuoted };
+
+        return new YamlScalarNode(value.ToString()) { Style = ScalarStyle.DoubleQuoted };
+    }
+}

--- a/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
+++ b/src/SwaggerMerge.SDK/Document/YamlDocumentFormatHandler.cs
@@ -21,8 +21,16 @@ public class YamlDocumentFormatHandler : IDocumentFormatHandler
     /// <inheritdoc/>
     public SwaggerDocument Deserialize(string content)
     {
-        var json = ConvertYamlToJson(content);
-        return _jsonHandler.Deserialize(json);
+        try
+        {
+            var json = ConvertYamlToJson(content);
+            return _jsonHandler.Deserialize(json);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or JsonException or YamlException)
+        {
+            throw new InvalidOperationException(
+                "The Swagger document YAML could not be loaded correctly as the format is not as expected.", ex);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/SwaggerMerge.SDK/SwaggerMerge.SDK.csproj
+++ b/src/SwaggerMerge.SDK/SwaggerMerge.SDK.csproj
@@ -23,4 +23,8 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.203" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/test/SwaggerMerge.AotCompatibility.TestApp/Documents/pet.swagger.yaml
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/Documents/pet.swagger.yaml
@@ -1,0 +1,70 @@
+swagger: "2.0"
+info:
+  description: >-
+    This is a sample server Petstore server.
+  version: "1.0.0"
+  title: Swagger Petstore 2.0
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /v2
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+schemes:
+  - https
+  - http
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: true
+          schema:
+            type: object
+            required:
+              - name
+              - photoUrls
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+                example: doggie
+              status:
+                type: string
+                description: pet status in the store
+                enum:
+                  - available
+                  - pending
+                  - sold
+      responses:
+        "400":
+          description: Invalid input
+        "422":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets

--- a/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMerge.AotCompatibility.TestApp.csproj
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMerge.AotCompatibility.TestApp.csproj
@@ -28,6 +28,9 @@
     <None Update="Documents\user.swagger.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Documents\pet.swagger.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
@@ -26,6 +26,32 @@ internal sealed class SwaggerMergeHandlerAotTest
         Assert(d.Host == "localhost", "Host was not set.");
         Assert(d.BasePath == "/api/", "BasePath was not set.");
         Assert(d.Paths is { Count: > 0 }, "No paths were merged.");
+
+        TestYamlRoundTrip();
+    }
+
+    [UnconditionalSuppressMessage("", "IL2026", Justification = "YAML conversion uses untyped intermediary objects only.")]
+    private static void TestYamlRoundTrip()
+    {
+        var handler = new SwaggerDocumentHandler();
+
+        // Load from YAML
+        var yamlContent = File.ReadAllText("Documents/pet.swagger.yaml");
+        var docFromYaml = handler.LoadFromYaml(yamlContent);
+        Assert(docFromYaml.SwaggerVersion == "2.0", "YAML load: swagger version was not 2.0.");
+        Assert(docFromYaml.Paths is { Count: > 0 }, "YAML load: no paths were loaded.");
+
+        // Save as YAML and reload
+        handler.SaveToPathAsync(docFromYaml, "Documents/pet.roundtrip.yaml", DocumentFormat.Yaml).GetAwaiter().GetResult();
+        var reloaded = handler.LoadFromFilePathAsync("Documents/pet.roundtrip.yaml").GetAwaiter().GetResult();
+        Assert(reloaded.SwaggerVersion == "2.0", "YAML round-trip: swagger version was not 2.0.");
+        Assert(reloaded.Paths is { Count: > 0 }, "YAML round-trip: no paths after reload.");
+        Assert(reloaded.Info.Title == docFromYaml.Info.Title, "YAML round-trip: title mismatch.");
+
+        // Cross-format: save YAML-loaded doc as JSON, reload
+        handler.SaveToPathAsync(docFromYaml, "Documents/pet.fromyaml.json", DocumentFormat.Json).GetAwaiter().GetResult();
+        var jsonReloaded = handler.LoadFromFilePathAsync("Documents/pet.fromyaml.json").GetAwaiter().GetResult();
+        Assert(jsonReloaded.Paths is { Count: > 0 }, "Cross-format: no paths after YAML-to-JSON round-trip.");
     }
 
     private static SwaggerMergeConfiguration GetSwaggerMergeConfiguration()

--- a/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
@@ -26,10 +26,31 @@ public class DocumentFormatDetectionTests
     }
 
     [Fact]
+    public void DetectFormat_UnknownExtension_WithJsonArrayContent_ReturnsJson()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "[{\"id\": 1}]");
+        Assert.Equal(DocumentFormat.Json, result);
+    }
+
+    [Fact]
     public void DetectFormat_UnknownExtension_WithYamlContent_ReturnsYaml()
     {
         var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "swagger: '2.0'");
         Assert.Equal(DocumentFormat.Yaml, result);
+    }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_WithWhitespaceContent_DefaultsToJson()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "   ");
+        Assert.Equal(DocumentFormat.Json, result);
+    }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_WithEmptyContent_DefaultsToJson()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "");
+        Assert.Equal(DocumentFormat.Json, result);
     }
 
     [Fact]

--- a/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
@@ -73,4 +73,12 @@ public class DocumentFormatDetectionTests
         var result = ISwaggerDocumentHandler.DetectFormat("file.yaml", "{ }");
         Assert.Equal(DocumentFormat.Yaml, result);
     }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_WithYamlFlowStyle_ReturnsYaml()
+    {
+        // YAML flow-style looks like JSON but has unquoted keys
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "{swagger: \"2.0\", info: {title: test}}");
+        Assert.Equal(DocumentFormat.Yaml, result);
+    }
 }

--- a/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/DocumentFormatDetectionTests.cs
@@ -1,0 +1,55 @@
+namespace SwaggerMerge.SDK.Tests;
+
+using SwaggerMerge.Document;
+using Xunit;
+
+public class DocumentFormatDetectionTests
+{
+    [Theory]
+    [InlineData("file.json", DocumentFormat.Json)]
+    [InlineData("file.yaml", DocumentFormat.Yaml)]
+    [InlineData("file.yml", DocumentFormat.Yaml)]
+    [InlineData("path/to/file.JSON", DocumentFormat.Json)]
+    [InlineData("path/to/file.YAML", DocumentFormat.Yaml)]
+    [InlineData("path/to/file.YML", DocumentFormat.Yaml)]
+    public void DetectFormat_ByExtension_ReturnsCorrectFormat(string filePath, DocumentFormat expected)
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat(filePath);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_WithJsonContent_ReturnsJson()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "{ \"swagger\": \"2.0\" }");
+        Assert.Equal(DocumentFormat.Json, result);
+    }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_WithYamlContent_ReturnsYaml()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt", "swagger: '2.0'");
+        Assert.Equal(DocumentFormat.Yaml, result);
+    }
+
+    [Fact]
+    public void DetectFormat_UnknownExtension_NoContent_DefaultsToJson()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.txt");
+        Assert.Equal(DocumentFormat.Json, result);
+    }
+
+    [Fact]
+    public void DetectFormat_JsonExtension_IgnoresContent()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.json", "swagger: '2.0'");
+        Assert.Equal(DocumentFormat.Json, result);
+    }
+
+    [Fact]
+    public void DetectFormat_YamlExtension_IgnoresContent()
+    {
+        var result = ISwaggerDocumentHandler.DetectFormat("file.yaml", "{ }");
+        Assert.Equal(DocumentFormat.Yaml, result);
+    }
+}

--- a/test/SwaggerMerge.SDK.Tests/Documents/pet.swagger.yaml
+++ b/test/SwaggerMerge.SDK.Tests/Documents/pet.swagger.yaml
@@ -1,0 +1,162 @@
+swagger: "2.0"
+info:
+  description: >-
+    This is a sample server Petstore server.
+  version: "1.0.0"
+  title: Swagger Petstore 2.0
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /v2
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+schemes:
+  - https
+  - http
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ""
+      operationId: addPet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: true
+          schema:
+            type: object
+            required:
+              - name
+              - photoUrls
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+                example: doggie
+              status:
+                type: string
+                description: pet status in the store
+                enum:
+                  - available
+                  - pending
+                  - sold
+      responses:
+        "400":
+          description: Invalid input
+        "422":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ""
+      operationId: updatePet
+      consumes:
+        - application/json
+        - application/xml
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Pet object that needs to be added to the store
+          required: true
+          schema:
+            type: object
+            required:
+              - name
+              - photoUrls
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+                example: doggie
+              status:
+                type: string
+                description: pet status in the store
+                enum:
+                  - available
+                  - pending
+                  - sold
+      responses:
+        "400":
+          description: Invalid ID supplied
+        "404":
+          description: Pet not found
+        "422":
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          type: array
+          items:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+          collectionFormat: multi
+      responses:
+        "200":
+          description: successful operation
+        "400":
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+securityDefinitions:
+  petstore_auth:
+    type: oauth2
+    authorizationUrl: http://petstore.swagger.io/oauth/dialog
+    flow: implicit
+    scopes:
+      write:pets: modify pets in your account
+      read:pets: read your pets
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header

--- a/test/SwaggerMerge.SDK.Tests/Documents/store.swagger.yaml
+++ b/test/SwaggerMerge.SDK.Tests/Documents/store.swagger.yaml
@@ -1,0 +1,91 @@
+swagger: "2.0"
+info:
+  description: >-
+    This is a sample server Petstore server.
+  version: "1.0.0"
+  title: Swagger Petstore 2.0
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.io
+basePath: /v2
+tags:
+  - name: store
+    description: Access to Petstore orders
+schemes:
+  - https
+  - http
+paths:
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        "200":
+          description: successful operation
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+              format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ""
+      operationId: placeOrder
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: order placed for purchasing the pet
+          required: true
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int64
+              petId:
+                type: integer
+                format: int64
+              quantity:
+                type: integer
+                format: int32
+              shipDate:
+                type: string
+                format: date-time
+              status:
+                type: string
+                description: Order Status
+                enum:
+                  - placed
+                  - approved
+                  - delivered
+              complete:
+                type: boolean
+                default: false
+      responses:
+        "200":
+          description: successful operation
+        "400":
+          description: Invalid Order
+securityDefinitions:
+  api_key:
+    type: apiKey
+    name: api_key
+    in: header

--- a/test/SwaggerMerge.SDK.Tests/SwaggerDocumentHandlerTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/SwaggerDocumentHandlerTests.cs
@@ -81,4 +81,145 @@ public class SwaggerDocumentHandlerTests
         Assert.Equal(document.Host, roundTripped.Host);
         Assert.Equal(document.BasePath, roundTripped.BasePath);
     }
+
+    [Fact]
+    public async Task LoadFromFilePathAsync_YamlFile_ReturnsDocument()
+    {
+        var document = await _handler.LoadFromFilePathAsync("Documents/pet.swagger.yaml");
+
+        Assert.Equal("2.0", document.SwaggerVersion);
+        Assert.Equal("Swagger Petstore 2.0", document.Info.Title);
+        Assert.Equal("1.0.0", document.Info.Version);
+        Assert.NotNull(document.Paths);
+        Assert.True(document.Paths.Count > 0);
+        Assert.Contains("/pet", document.Paths.Keys);
+    }
+
+    [Fact]
+    public async Task LoadFromFilePathAsync_YamlStoreFile_ReturnsDocumentWithPaths()
+    {
+        var document = await _handler.LoadFromFilePathAsync("Documents/store.swagger.yaml");
+
+        Assert.Equal("Swagger Petstore 2.0", document.Info.Title);
+        Assert.NotNull(document.Paths);
+        Assert.Contains("/store/inventory", document.Paths.Keys);
+        Assert.Contains("/store/order", document.Paths.Keys);
+    }
+
+    [Fact]
+    public void LoadFromYaml_ValidYaml_ReturnsDocument()
+    {
+        var yaml = File.ReadAllText("Documents/pet.swagger.yaml");
+        var document = _handler.LoadFromYaml(yaml);
+
+        Assert.Equal("Swagger Petstore 2.0", document.Info.Title);
+        Assert.NotNull(document.Paths);
+        Assert.Contains("/pet", document.Paths.Keys);
+    }
+
+    [Fact]
+    public async Task SaveToPathAsync_YamlExtension_SavesAsYaml()
+    {
+        var original = await _handler.LoadFromFilePathAsync("Documents/pet.swagger.json");
+        var tempPath = Path.Combine(Path.GetTempPath(), $"swagger-test-{Guid.NewGuid()}.yaml");
+
+        try
+        {
+            await _handler.SaveToPathAsync(original, tempPath);
+            var content = await File.ReadAllTextAsync(tempPath);
+
+            Assert.StartsWith("swagger:", content.TrimStart());
+            Assert.Contains("Swagger Petstore 2.0", content);
+            Assert.DoesNotContain("\"swagger\":", content);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task SaveToPathAsync_ExplicitYamlFormat_SavesAsYaml()
+    {
+        var original = await _handler.LoadFromFilePathAsync("Documents/pet.swagger.json");
+        var tempPath = Path.Combine(Path.GetTempPath(), $"swagger-test-{Guid.NewGuid()}.txt");
+
+        try
+        {
+            await _handler.SaveToPathAsync(original, tempPath, DocumentFormat.Yaml);
+            var content = await File.ReadAllTextAsync(tempPath);
+
+            Assert.StartsWith("swagger:", content.TrimStart());
+            Assert.DoesNotContain("\"swagger\":", content);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task YamlRoundTrip_LoadYamlSaveYamlReload_PreservesStructure()
+    {
+        var original = await _handler.LoadFromFilePathAsync("Documents/pet.swagger.yaml");
+        var tempPath = Path.Combine(Path.GetTempPath(), $"swagger-test-{Guid.NewGuid()}.yaml");
+
+        try
+        {
+            await _handler.SaveToPathAsync(original, tempPath);
+            var reloaded = await _handler.LoadFromFilePathAsync(tempPath);
+
+            Assert.Equal(original.Info.Title, reloaded.Info.Title);
+            Assert.Equal(original.Info.Version, reloaded.Info.Version);
+            Assert.Equal(original.Paths?.Count, reloaded.Paths?.Count);
+            Assert.Equal(original.Host, reloaded.Host);
+            Assert.Equal(original.BasePath, reloaded.BasePath);
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
+    }
+
+    [Fact]
+    public async Task CrossFormat_LoadJsonSaveYamlReloadFromYaml_PreservesStructure()
+    {
+        var original = await _handler.LoadFromFilePathAsync("Documents/store.swagger.json");
+        var tempYaml = Path.Combine(Path.GetTempPath(), $"swagger-test-{Guid.NewGuid()}.yaml");
+
+        try
+        {
+            await _handler.SaveToPathAsync(original, tempYaml);
+            var reloaded = await _handler.LoadFromFilePathAsync(tempYaml);
+
+            Assert.Equal(original.Info.Title, reloaded.Info.Title);
+            Assert.Equal(original.Info.Version, reloaded.Info.Version);
+            Assert.Equal(original.Paths?.Count, reloaded.Paths?.Count);
+        }
+        finally
+        {
+            File.Delete(tempYaml);
+        }
+    }
+
+    [Fact]
+    public async Task CrossFormat_LoadYamlSaveJsonReloadFromJson_PreservesStructure()
+    {
+        var original = await _handler.LoadFromFilePathAsync("Documents/pet.swagger.yaml");
+        var tempJson = Path.Combine(Path.GetTempPath(), $"swagger-test-{Guid.NewGuid()}.json");
+
+        try
+        {
+            await _handler.SaveToPathAsync(original, tempJson);
+            var reloaded = await _handler.LoadFromFilePathAsync(tempJson);
+
+            Assert.Equal(original.Info.Title, reloaded.Info.Title);
+            Assert.Equal(original.Info.Version, reloaded.Info.Version);
+            Assert.Equal(original.Paths?.Count, reloaded.Paths?.Count);
+        }
+        finally
+        {
+            File.Delete(tempJson);
+        }
+    }
 }

--- a/test/SwaggerMerge.SDK.Tests/SwaggerDocumentHandlerTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/SwaggerDocumentHandlerTests.cs
@@ -222,4 +222,11 @@ public class SwaggerDocumentHandlerTests
             File.Delete(tempJson);
         }
     }
+
+    [Fact]
+    public void LoadFromYaml_InvalidYaml_ThrowsWithYamlMessage()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => _handler.LoadFromYaml("not: [valid: yaml: content"));
+        Assert.Contains("YAML", ex.Message);
+    }
 }

--- a/test/SwaggerMerge.SDK.Tests/SwaggerMerge.SDK.Tests.csproj
+++ b/test/SwaggerMerge.SDK.Tests/SwaggerMerge.SDK.Tests.csproj
@@ -28,6 +28,8 @@
 
   <ItemGroup>
     <Content Include="Documents\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Documents\**\*.yaml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Documents\**\*.yml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/test/SwaggerMerge.SDK.Tests/SwaggerMergeHandlerTests.cs
+++ b/test/SwaggerMerge.SDK.Tests/SwaggerMergeHandlerTests.cs
@@ -289,4 +289,32 @@ public class SwaggerMergeHandlerTests
         Assert.NotNull(result.Paths);
         Assert.Contains("/pet", result.Paths.Keys);
     }
+
+    [Fact]
+    public void Merge_MixedFormatInputs_JsonAndYaml_CombinesPaths()
+    {
+        var jsonDoc = TestDocumentLoader.Load("pet.swagger.json");
+        var yamlDoc = TestDocumentLoader.LoadYaml("store.swagger.yaml");
+
+        var config = new SwaggerMergeConfiguration
+        {
+            Inputs = new[]
+            {
+                new SwaggerInputConfiguration { File = jsonDoc },
+                new SwaggerInputConfiguration { File = yamlDoc }
+            },
+            Output = new SwaggerOutputConfiguration
+            {
+                Info = new SwaggerOutputInfoConfiguration { Title = "Mixed Format API", Version = "1.0" },
+                Host = "localhost"
+            }
+        };
+
+        var result = _handler.Merge(config);
+
+        Assert.Equal("Mixed Format API", result.Info.Title);
+        Assert.NotNull(result.Paths);
+        Assert.Contains("/pet", result.Paths.Keys);
+        Assert.Contains("/store/inventory", result.Paths.Keys);
+    }
 }

--- a/test/SwaggerMerge.SDK.Tests/TestDocumentLoader.cs
+++ b/test/SwaggerMerge.SDK.Tests/TestDocumentLoader.cs
@@ -5,10 +5,18 @@ using SwaggerMerge.Document;
 
 internal static class TestDocumentLoader
 {
+    private static readonly SwaggerDocumentHandler Handler = new();
+
     public static SwaggerDocument Load(string fileName)
     {
         var json = File.ReadAllText(Path.Combine("Documents", fileName));
         return JsonSerializer.Deserialize(json, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument)
                ?? throw new InvalidOperationException($"Failed to deserialize {fileName}");
+    }
+
+    public static SwaggerDocument LoadYaml(string fileName)
+    {
+        var yaml = File.ReadAllText(Path.Combine("Documents", fileName));
+        return Handler.LoadFromYaml(yaml);
     }
 }


### PR DESCRIPTION
This pull request introduces foundational support for YAML format and format detection in the SwaggerMerge SDK, paving the way for OpenAPI V3 support. The main changes include adding YAML serialization/deserialization using YamlDotNet, updating the document handler interface and implementation to support both JSON and YAML, and introducing robust format detection logic. These changes are the first step in enabling the tool to work with both JSON and YAML Swagger/OpenAPI files.

**YAML and Format Support Enhancements:**

* Added a new `DocumentFormat` enum to represent supported formats (`Json`, `Yaml`).
* Updated the `ISwaggerDocumentHandler` interface to support loading and saving Swagger documents in both JSON and YAML formats, including new methods for YAML, format detection, and format-aware save operations. [[1]](diffhunk://#diff-fe78c585b56f4993d12834941926efbde8d9418cff35a28ec3b6abfd5f9203dbL9-R12) [[2]](diffhunk://#diff-fe78c585b56f4993d12834941926efbde8d9418cff35a28ec3b6abfd5f9203dbL23-R63)
* Implemented YAML serialization and deserialization in `SwaggerDocumentHandler` using YamlDotNet, with conversion logic between YAML and JSON, and ensured AOT compatibility. [[1]](diffhunk://#diff-c1d8f492d30ab2c4a9c5dcaec2ce15fa6295dd16a26754de67d4e5861e550858R3-R23) [[2]](diffhunk://#diff-c1d8f492d30ab2c4a9c5dcaec2ce15fa6295dd16a26754de67d4e5861e550858L36-R125)
* Enhanced file format detection logic based on file extension and content, ensuring seamless handling of both JSON and YAML files. [[1]](diffhunk://#diff-fe78c585b56f4993d12834941926efbde8d9418cff35a28ec3b6abfd5f9203dbL23-R63) [[2]](diffhunk://#diff-c1d8f492d30ab2c4a9c5dcaec2ce15fa6295dd16a26754de67d4e5861e550858R3-R23)
* Added `YamlDotNet` as a dependency in the SDK project.

**Documentation and Planning:**

* Added a comprehensive feature plan document outlining the phased approach for OpenAPI V3 and YAML support, including risk assessment and work breakdown.