### PR TITLE
test(aot): add OpenAPI V3 merge and YAML round-trip AOT tests

### DIFF
--- a/test/SwaggerMerge.AotCompatibility.TestApp/Documents/pet.openapi.json
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/Documents/pet.openapi.json
@@ -1,0 +1,151 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Petstore API",
+    "description": "A sample API that uses a petstore as an example",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v3",
+      "description": "Production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet object that needs to be added",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Pet created"
+          },
+          "400": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "api_key": []
+    }
+  ]
+}

--- a/test/SwaggerMerge.AotCompatibility.TestApp/Documents/store.openapi.json
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/Documents/store.openapi.json
@@ -1,0 +1,160 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Store API",
+    "description": "Store inventory and order management",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v3",
+      "description": "Production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    }
+  ],
+  "paths": {
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "description": "Order placed for purchasing the pet",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid order"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of order to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": ["placed", "approved", "delivered"]
+          },
+          "complete": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMerge.AotCompatibility.TestApp.csproj
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMerge.AotCompatibility.TestApp.csproj
@@ -31,6 +31,12 @@
     <None Update="Documents\pet.swagger.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Documents\pet.openapi.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Documents\store.openapi.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
@@ -4,6 +4,11 @@ using SwaggerMerge.V2.Configuration;
 using SwaggerMerge.V2.Configuration.Input;
 using SwaggerMerge.V2.Configuration.Output;
 using SwaggerMerge.V2.Document;
+using SwaggerMerge.V3;
+using SwaggerMerge.V3.Configuration;
+using SwaggerMerge.V3.Configuration.Input;
+using SwaggerMerge.V3.Configuration.Output;
+using SwaggerMerge.V3.Document;
 using SwaggerMerge.Common.Document;
 
 namespace SwaggerMerge.AotCompatibility.TestApp;
@@ -29,6 +34,9 @@ internal sealed class SwaggerMergeHandlerAotTest
         Assert(d.Paths is { Count: > 0 }, "No paths were merged.");
 
         TestYamlRoundTrip();
+
+        TestOpenApiV3Merge();
+        TestOpenApiV3YamlRoundTrip();
     }
 
     [UnconditionalSuppressMessage("", "IL2026", Justification = "YAML conversion uses untyped intermediary objects only.")]
@@ -53,6 +61,67 @@ internal sealed class SwaggerMergeHandlerAotTest
         handler.SaveToPathAsync(docFromYaml, "Documents/pet.fromyaml.json", DocumentFormat.Json).GetAwaiter().GetResult();
         var jsonReloaded = handler.LoadFromFilePathAsync("Documents/pet.fromyaml.json").GetAwaiter().GetResult();
         Assert(jsonReloaded.Paths is { Count: > 0 }, "Cross-format: no paths after YAML-to-JSON round-trip.");
+    }
+
+    [UnconditionalSuppressMessage("", "IL2026", Justification = "Property presence guaranteed by explicit hints.")]
+    private static void TestOpenApiV3Merge()
+    {
+        var merger = new OpenApiMergeHandler();
+        var jsonHandler = new OpenApiJsonDocumentFormatHandler();
+
+        GuaranteeProperties<OpenApiMergeConfiguration>();
+
+        var documents = Directory.EnumerateFiles("Documents", "*.openapi.json")
+            .Select(File.ReadAllText)
+            .Select(jsonHandler.Deserialize)
+            .ToList();
+
+        var config = new OpenApiMergeConfiguration
+        {
+            Inputs = documents.Select(d => new OpenApiInputConfiguration { File = d }),
+            Output = new OpenApiOutputConfiguration
+            {
+                Info = new OpenApiOutputInfoConfiguration { Title = "OpenAPI Merged", Version = "2.0.0" },
+                Servers = new List<OpenApiServer>
+                {
+                    new() { Url = "https://localhost/api", Description = "Local server" }
+                }
+            }
+        };
+
+        var merged = merger.Merge(config);
+
+        File.WriteAllText("Documents/merged.openapi.json",
+            JsonSerializer.Serialize(merged, OpenApiDocumentJsonSerializerContext.Default.OpenApiDocument));
+
+        Assert(merged.Info is { Title: "OpenAPI Merged" }, "V3: Title was not set.");
+        Assert(merged.Info is { Version: "2.0.0" }, "V3: Version was not set.");
+        Assert(merged.Paths is { Count: > 0 }, "V3: No paths were merged.");
+        Assert(merged.Servers is { Count: > 0 }, "V3: Servers were not set.");
+    }
+
+    [UnconditionalSuppressMessage("", "IL2026", Justification = "YAML conversion uses untyped intermediary objects only.")]
+    private static void TestOpenApiV3YamlRoundTrip()
+    {
+        var handler = new OpenApiDocumentHandler();
+
+        // Load from JSON
+        var jsonContent = File.ReadAllText("Documents/pet.openapi.json");
+        var docFromJson = handler.LoadFromJson(jsonContent);
+        Assert(docFromJson.OpenApiVersion == "3.0.3", "V3 YAML: openapi version was not 3.0.3.");
+        Assert(docFromJson.Paths is { Count: > 0 }, "V3 YAML: no paths were loaded.");
+
+        // Save as YAML and reload
+        handler.SaveToPathAsync(docFromJson, "Documents/pet.openapi.roundtrip.yaml", DocumentFormat.Yaml).GetAwaiter().GetResult();
+        var reloaded = handler.LoadFromFilePathAsync("Documents/pet.openapi.roundtrip.yaml").GetAwaiter().GetResult();
+        Assert(reloaded.OpenApiVersion == "3.0.3", "V3 YAML round-trip: openapi version was not 3.0.3.");
+        Assert(reloaded.Paths is { Count: > 0 }, "V3 YAML round-trip: no paths after reload.");
+        Assert(reloaded.Info.Title == docFromJson.Info.Title, "V3 YAML round-trip: title mismatch.");
+
+        // Cross-format: save YAML-loaded doc as JSON, reload
+        handler.SaveToPathAsync(reloaded, "Documents/pet.openapi.fromyaml.json", DocumentFormat.Json).GetAwaiter().GetResult();
+        var jsonReloaded = handler.LoadFromFilePathAsync("Documents/pet.openapi.fromyaml.json").GetAwaiter().GetResult();
+        Assert(jsonReloaded.Paths is { Count: > 0 }, "V3 Cross-format: no paths after YAML-to-JSON round-trip.");
     }
 
     private static SwaggerMergeConfiguration GetSwaggerMergeConfiguration()

--- a/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
+++ b/test/SwaggerMerge.AotCompatibility.TestApp/SwaggerMergeHandlerAotTest.cs
@@ -25,7 +25,7 @@ internal sealed class SwaggerMergeHandlerAotTest
         var d = merger.Merge(GetSwaggerMergeConfiguration());
 
         // Save the merged document to a file for manual inspection
-        File.WriteAllText("Documents/merged.swagger.json", JsonSerializer.Serialize(d, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument));
+        File.WriteAllText("Documents/merged.swagger.result.json", JsonSerializer.Serialize(d, SwaggerDocumentJsonSerializerContext.Default.SwaggerDocument));
 
         Assert(d.Info is { Title: "Swagger Merged" }, "Title was not set.");
         Assert(d.Info is { Version: "1.0.0" }, "Version was not set.");
@@ -91,7 +91,7 @@ internal sealed class SwaggerMergeHandlerAotTest
 
         var merged = merger.Merge(config);
 
-        File.WriteAllText("Documents/merged.openapi.json",
+        File.WriteAllText("Documents/merged.openapi.result.json",
             JsonSerializer.Serialize(merged, OpenApiDocumentJsonSerializerContext.Default.OpenApiDocument));
 
         Assert(merged.Info is { Title: "OpenAPI Merged" }, "V3: Title was not set.");


### PR DESCRIPTION
This pull request adds support for OpenAPI v3 document merging and round-trip serialization tests to the AOT compatibility test application. It introduces new OpenAPI v3 test documents, updates the project file to include them, and extends the test suite to cover merging and serialization/deserialization of OpenAPI v3 documents in both JSON and YAML formats.

**OpenAPI v3 Test Support:**

* Added `pet.openapi.json` and `store.openapi.json` OpenAPI v3 documents to the `Documents` folder for use in tests. [[1]](diffhunk://#diff-c65fa0bd499be013e6ea982d4d995be22d46590adfa0911610e79a598b919300R1-R151) [[2]](diffhunk://#diff-3638a9495d98ce6dfbdda03c15f1f2c816f41905c22507e2afe199f0b3168991R1-R160)
* Updated the project file (`SwaggerMerge.AotCompatibility.TestApp.csproj`) to copy the new OpenAPI v3 documents to the output directory.

**Test Suite Enhancements:**

* Updated `SwaggerMergeHandlerAotTest.cs` to import OpenAPI v3 handler and configuration types, and to invoke new OpenAPI v3 test methods. [[1]](diffhunk://#diff-3e1442da7d4545c3341e644e0a1886718b411c18c9a0c11f4c922e6404b23caeR7-R11) [[2]](diffhunk://#diff-3e1442da7d4545c3341e644e0a1886718b411c18c9a0c11f4c922e6404b23caeR37-R39)
* Added `TestOpenApiV3Merge()` to verify merging of OpenAPI v3 documents and validate merged output properties such as title, version, paths, and servers.
* Added `TestOpenApiV3YamlRoundTrip()` to test round-trip serialization/deserialization of OpenAPI v3 documents between JSON and YAML formats, including cross-format validation.